### PR TITLE
Defer setup to avoid module import-time side-effects

### DIFF
--- a/library/pianohat.py
+++ b/library/pianohat.py
@@ -6,7 +6,7 @@ from sys import exit
 try:
     import cap1xxx
 except ImportError:
-    exit("This library requires the cap1xxx module\nInstall with: sudo pip install cap1xxx")
+    raise ImportError("This library requires the cap1xxx module\nInstall with: sudo pip install cap1xxx")
 
 __version__ = '0.0.5'
 
@@ -15,6 +15,7 @@ _on_octave_up   = None
 _on_octave_down = None
 _on_instrument  = None
 
+_is_setup = False
 _pressed = [False for x in range(16)]
 
 PRESSED  = True
@@ -81,6 +82,8 @@ def auto_leds(enable = True):
 
     """
 
+    setup()
+
     _piano_ctog._write_byte(cap1xxx.R_LED_LINKING, 0b11111111 * enable)
     _piano_atoc._write_byte(cap1xxx.R_LED_LINKING, 0b11111111 * enable)
 
@@ -91,6 +94,8 @@ def set_led(index, state):
     :param state: state to set the LED: either False or True
 
     """
+
+    setup()
 
     if index >= 8:
         _piano_atoc.set_led_state(index-8,state)
@@ -105,6 +110,8 @@ def set_led_ramp_rate(rise,fall):
 
     """
 
+    setup()
+
     _piano_ctog.set_led_direct_ramp_rate(rise, fall)
     _piano_atoc.set_led_direct_ramp_rate(rise, fall)
 
@@ -114,6 +121,8 @@ def get_state(index=-1):
     :param index: index of key to return, from 0 to 15
 
     """
+
+    setup()
 
     if index > 0 and index < 16:
         return _pressed[index]
@@ -133,6 +142,7 @@ def on_note(handler):
     """
 
     global _on_note
+    setup()
     _on_note = handler
 
 def on_octave_up(handler):
@@ -145,6 +155,7 @@ def on_octave_up(handler):
     """
 
     global _on_octave_up
+    setup()
     _on_octave_up = handler
 
 def on_octave_down(handler):
@@ -157,6 +168,7 @@ def on_octave_down(handler):
     """
 
     global _on_octave_down
+    setup()
     _on_octave_down = handler
 
 def on_instrument(handler):
@@ -169,21 +181,31 @@ def on_instrument(handler):
     """
 
     global _on_instrument
+    setup()
     _on_instrument = handler
 
-# Keys C, C#, D, D#, E, F, F# and G
-_piano_ctog = cap1xxx.Cap1188(i2c_addr=0x28, alert_pin=4)
-_setup_cap(_piano_ctog)
+def setup():
+    global _is_setup, _piano_ctog, _piano_atoc
 
-# Keys G#, A, A#, B, C, Instrument, Octave -, Octave +
-_piano_atoc = cap1xxx.Cap1188(i2c_addr=0x2b, alert_pin=27)
-_setup_cap(_piano_atoc)
+    if _is_setup:
+        return True
 
-for x in range(0,8):
-    _piano_ctog.on(x,event='press',  handler=lambda evt: _handle_event(0,evt,PRESSED ))
-    _piano_ctog.on(x,event='release',handler=lambda evt: _handle_event(0,evt,RELEASED))
-    _piano_atoc.on(x,event='press',  handler=lambda evt: _handle_event(1,evt,PRESSED ))
-    _piano_atoc.on(x,event='release',handler=lambda evt: _handle_event(1,evt,RELEASED))
+    # Keys C, C#, D, D#, E, F, F# and G
+    _piano_ctog = cap1xxx.Cap1188(i2c_addr=0x28, alert_pin=4)
+    _setup_cap(_piano_ctog)
 
-#_piano_ctog.clear_interrupt()
-#_piano_atoc.clear_interrupt()
+    # Keys G#, A, A#, B, C, Instrument, Octave -, Octave +
+    _piano_atoc = cap1xxx.Cap1188(i2c_addr=0x2b, alert_pin=27)
+    _setup_cap(_piano_atoc)
+
+    for x in range(0,8):
+        _piano_ctog.on(x,event='press',  handler=lambda evt: _handle_event(0,evt,PRESSED ))
+        _piano_ctog.on(x,event='release',handler=lambda evt: _handle_event(0,evt,RELEASED))
+        _piano_atoc.on(x,event='press',  handler=lambda evt: _handle_event(1,evt,PRESSED ))
+        _piano_atoc.on(x,event='release',handler=lambda evt: _handle_event(1,evt,RELEASED))
+
+    #_piano_ctog.clear_interrupt()
+    #_piano_atoc.clear_interrupt()
+
+    _is_setup = True
+


### PR DESCRIPTION
This PR makes several "friendly neighbour" changes to the Piano HAT library to avoid code being unnecessarily executed upon import.

See here for details of the problems import-time side-effects can have: https://www.raspberrypi.org/forums/viewtopic.php?f=32&t=193502&p=1212488#p1212488