### PR TITLE
Modernize python3 64bit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+## Description
+
+Please provide a clear and concise description of your changes.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Code quality improvement
+
+## Testing
+
+Please describe the tests you ran to verify your changes:
+
+- [ ] Tested on actual Piano HAT hardware
+- [ ] Tested import: `python3 -c "import pianohat"`
+- [ ] Tested examples (which ones?): 
+- [ ] Code passes flake8 linting
+- [ ] Code formatted with black
+- [ ] Type checking passes (mypy)
+
+## Hardware Testing (if applicable)
+
+- [ ] All 13 piano keys work
+- [ ] Octave up/down buttons work
+- [ ] Instrument button works
+- [ ] LED control works
+- [ ] Auto LEDs work
+
+## Environment
+
+- **Raspberry Pi Model:** (e.g., Pi 4, Pi 5, Pi Zero 2W)
+- **OS Version:** (e.g., Raspberry Pi OS Bookworm 64-bit)
+- **Python Version:** (e.g., 3.11.2)
+- **Architecture:** (e.g., aarch64, armhf)
+
+## Checklist
+
+- [ ] My code follows the project's code style
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have updated the documentation accordingly
+- [ ] I have added an entry to CHANGELOG.md
+- [ ] My changes generate no new warnings
+- [ ] I have tested my changes on actual hardware (if applicable)
+
+## Related Issues
+
+Closes #(issue number)
+
+## Additional Notes
+
+Add any other context about the pull request here.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,88 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    
+    - name: Install build dependencies
+      run: python -m pip install --upgrade pip build
+    
+    - name: Build package
+      run: |
+        cd library
+        python -m build
+    
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: library/dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pianohat
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Sign and upload to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,90 @@
+name: Python Package CI
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 black mypy
+    
+    - name: Lint with flake8
+      run: |
+        # Stop the build if there are Python syntax errors or undefined names
+        flake8 library/pianohat.py --count --select=E9,F63,F7,F82 --show-source --statistics
+        # Exit-zero treats all errors as warnings
+        flake8 library/pianohat.py --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
+    
+    - name: Check formatting with black
+      run: |
+        black --check --line-length 120 library/pianohat.py
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        cd library
+        pip install -e .
+    
+    - name: Test import
+      run: |
+        python -c "import pianohat; print('Version:', pianohat.__version__)"
+
+  build:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip build twine
+    
+    - name: Build package
+      run: |
+        cd library
+        python -m build
+    
+    - name: Check package
+      run: |
+        cd library
+        twine check dist/*
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: library/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-02-23
+
+### Added
+- Type hints throughout the library for better IDE support
+- Modern `pyproject.toml` packaging (PEP 517/518)
+- Support for Python 3.7 through 3.12
+- Support for 64-bit Raspberry Pi OS (aarch64)
+- GitHub Actions CI/CD workflows
+- Modern installation script (`install.sh`)
+- Requirements files for easy dependency management
+- Comprehensive documentation updates
+
+### Changed
+- **BREAKING**: Dropped Python 2.7 support (now requires Python 3.7+)
+- Updated all examples to use Python 3
+- Modernized code style and formatting
+- Improved error messages and documentation strings
+- Updated installation instructions for current Raspberry Pi OS
+
+### Removed
+- Python 2.7 support
+- Old `setup.py` (replaced with `pyproject.toml`)
+- Deprecated installation methods
+
+### Fixed
+- Integer division in examples for Python 3 compatibility
+- Import statements updated for modern best practices
+- Code formatting and style issues
+
+## [0.1.0] - 2015-XX-XX
+
+### Added
+- Initial release
+- Support for Piano HAT hardware
+- 13-key piano functionality
+- Octave up/down controls
+- Instrument selector
+- LED control
+- Example programs (piano, synth, MIDI, etc.)
+- Python 2.7 and Python 3 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-02-24
+
+### Credits
+- Pimoroni Ltd
+- Daniel Gentleman <code@danielgentleman.com>
+
+### Changed
+- Restored CAP1188 LED control (linking and manual on/off)
+- Lowered minimum CAP1188 dependency to match available PyPI versions
+
+### Fixed
+- LED APIs (`auto_leds`, `set_led`, `set_led_ramp_rate`) now work again
+
+## [0.3.0] - 2026-02-24
+
+### Changed
+- **BREAKING DEPENDENCY**: Replaced `cap1xxx` with `adafruit-circuitpython-cap1188`
+  - Old library had GPIO interrupt issues on modern Raspberry Pi OS (Bookworm)
+  - New library uses polling (no GPIO interrupts required)
+  - Works on modern 64-bit Raspberry Pi OS without GPIO configuration
+- Rewrote button detection to use polling thread instead of GPIO interrupts
+- LED control still handled via CAP1188 (no GPIO required)
+
+### Added
+- Polling-based button detection (background thread)
+- Full support for modern Raspberry Pi OS Bookworm (64-bit and 32-bit)
+- Debounce support (20ms polling interval)
+- Better error messages for I2C detection failures
+- CircuitPython/Blinka compatibility
+
+### Fixed
+- **MAJOR**: Button press detection on Raspberry Pi OS Bookworm
+- GPIO interrupt issues that prevented button events from firing
+- gpiochip512 offset compatibility issues
+
+### Compatibility Notes
+- **LED Control**: LEDs are controlled by the CAP1188 chips and do not require GPIO
+- **Migration**: No code changes needed if you only use button detection
+  - All example code continues to work unchanged
+  - Update dependencies: `pip install adafruit-circuitpython-cap1188`
+
 ## [0.2.0] - 2026-02-23
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,148 @@
+# Contributing to Piano HAT
+
+Thank you for your interest in contributing to Piano HAT! This document provides guidelines for contributing to this project.
+
+## Development Setup
+
+1. **Fork and clone the repository:**
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/piano-hat.git
+   cd piano-hat
+   ```
+
+2. **Create a virtual environment:**
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate  # On Linux/Mac
+   # or
+   venv\Scripts\activate  # On Windows
+   ```
+
+3. **Install development dependencies:**
+   ```bash
+   cd library
+   pip install -e ".[dev,examples]"
+   ```
+
+## Code Style
+
+This project follows PEP 8 style guidelines with these specifics:
+
+- **Line length:** 120 characters maximum
+- **Formatter:** Black
+- **Linter:** Flake8
+- **Type checker:** MyPy
+
+### Running code quality tools:
+
+```bash
+# Format code
+black library/pianohat.py
+
+# Lint code
+flake8 library/pianohat.py --max-line-length=120
+
+# Type check
+mypy library/pianohat.py
+```
+
+## Making Changes
+
+1. **Create a feature branch:**
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. **Make your changes:**
+   - Write clear, concise commit messages
+   - Add type hints to new functions
+   - Update documentation as needed
+   - Test your changes on actual hardware if possible
+
+3. **Test your changes:**
+   ```bash
+   # Import test
+   python3 -c "import pianohat; print(pianohat.__version__)"
+   
+   # Run examples (if you have hardware)
+   python3 examples/buttons.py
+   ```
+
+4. **Update the CHANGELOG:**
+   - Add your changes to the `[Unreleased]` section
+   - Follow the existing format
+
+## Submitting Changes
+
+1. **Push to your fork:**
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+2. **Create a Pull Request:**
+   - Use a clear, descriptive title
+   - Describe what changes you made and why
+   - Reference any related issues
+   - Ensure CI checks pass
+
+## Pull Request Checklist
+
+- [ ] Code follows the project's style guidelines
+- [ ] Code has been formatted with Black
+- [ ] Type hints added to new functions
+- [ ] Documentation updated (if needed)
+- [ ] CHANGELOG updated
+- [ ] Tested on actual hardware (if possible)
+- [ ] CI checks pass
+
+## Reporting Issues
+
+When reporting issues, please include:
+
+- **Hardware:** Raspberry Pi model and OS version
+- **Python version:** Output of `python3 --version`
+- **Library version:** Output of `pip3 show pianohat`
+- **Steps to reproduce:** Clear, numbered steps
+- **Expected behavior:** What should happen
+- **Actual behavior:** What actually happens
+- **Error messages:** Full error output/traceback
+
+## Testing on Hardware
+
+If you have a Piano HAT:
+
+1. **Test I2C detection:**
+   ```bash
+   i2cdetect -y 1
+   # Should show devices at 0x28 and 0x2b
+   ```
+
+2. **Test basic functionality:**
+   ```bash
+   python3 examples/buttons.py
+   python3 examples/leds.py
+   ```
+
+3. **Test your changes:**
+   - Verify all 13 piano keys work
+   - Test octave up/down buttons
+   - Test instrument button
+   - Test LED control
+
+## Code of Conduct
+
+- Be respectful and inclusive
+- Provide constructive feedback
+- Focus on what is best for the community
+- Show empathy towards others
+
+## Questions?
+
+Feel free to open an issue for:
+- Questions about development
+- Suggestions for improvements
+- Discussion about features
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,235 @@
+# Migration Guide: v0.1.0 to v0.2.0
+
+This guide helps you migrate from the old Piano HAT library (v0.1.0) to the modernized v0.2.0.
+
+## What Changed?
+
+### Python Version
+
+**Old (v0.1.0):**
+- Supported Python 2.7 and Python 3.x
+
+**New (v0.2.0):**
+- **Requires Python 3.7 or higher**
+- Python 2.7 is no longer supported
+
+### Installation Method
+
+**Old (v0.1.0):**
+```bash
+# The old curl script could break your system
+curl https://get.pimoroni.com/pianohat | bash
+```
+
+**New (v0.2.0):**
+```bash
+# Safe, modern installer
+curl -sSL https://raw.githubusercontent.com/pimoroni/piano-hat/master/install.sh | bash
+
+# Or manual install
+pip3 install pianohat
+```
+
+### Package Structure
+
+**Old (v0.1.0):**
+- Used `setup.py` for packaging
+
+**New (v0.2.0):**
+- Uses `pyproject.toml` (PEP 517/518)
+- Supports editable installs: `pip install -e .`
+
+## Code Changes Required
+
+### Good News! 🎉
+
+**No code changes are required!** The API remains completely compatible.
+
+Your existing code will work without modification:
+
+```python
+import pianohat
+
+pianohat.auto_leds(True)
+
+def handle_note(channel, pressed):
+    print(f"Note {channel} {'pressed' if pressed else 'released'}")
+
+pianohat.on_note(handle_note)
+```
+
+### Python 3 Updates (if migrating from Python 2)
+
+If you were using Python 2, you'll need to update your code:
+
+**Print statements:**
+```python
+# Python 2
+print "Hello"
+
+# Python 3
+print("Hello")
+```
+
+**Integer division:**
+```python
+# Python 2
+result = 10 / 3  # Returns 3
+
+# Python 3
+result = 10 // 3  # Returns 3 (use // for integer division)
+result = 10 / 3   # Returns 3.333... (regular division)
+```
+
+## System Requirements
+
+### Raspberry Pi OS
+
+**Old (v0.1.0):**
+- Designed for 32-bit Raspbian Jessie/Stretch
+
+**New (v0.2.0):**
+- Supports Raspberry Pi OS Bullseye (11) and Bookworm (12)
+- Works on both 32-bit (armhf) and 64-bit (aarch64)
+
+### I2C Setup
+
+I2C must be enabled. On modern Raspberry Pi OS:
+
+```bash
+sudo raspi-config
+# Navigate to: Interface Options → I2C → Enable
+```
+
+Or check your config file:
+```bash
+# On older systems:
+grep "dtparam=i2c_arm=on" /boot/config.txt
+
+# On newer systems (Bookworm+):
+grep "dtparam=i2c_arm=on" /boot/firmware/config.txt
+```
+
+## Uninstalling Old Version
+
+If you have the old version installed:
+
+```bash
+# Remove old pip packages
+sudo pip uninstall pianohat
+sudo pip3 uninstall pianohat
+
+# Remove old apt packages (if any)
+sudo apt-get remove python-pianohat python3-pianohat
+
+# Clean up old examples (optional)
+rm -rf ~/Pimoroni/pianohat
+```
+
+## Installing New Version
+
+### Option 1: Using the new installer (Recommended)
+
+```bash
+git clone https://github.com/pimoroni/piano-hat
+cd piano-hat
+chmod +x install.sh
+./install.sh --examples
+```
+
+### Option 2: Manual install
+
+```bash
+# System dependencies
+sudo apt-get update
+sudo apt-get install python3-pip python3-dev i2c-tools python3-smbus
+
+# Install library
+pip3 install pianohat
+
+# Install example dependencies (optional)
+pip3 install pygame numpy
+```
+
+## Testing the Migration
+
+1. **Check Python version:**
+   ```bash
+   python3 --version
+   # Should be 3.7 or higher
+   ```
+
+2. **Verify installation:**
+   ```bash
+   pip3 show pianohat
+   # Should show version 0.2.0 or higher
+   ```
+
+3. **Test I2C:**
+   ```bash
+   i2cdetect -y 1
+   # Should show devices at addresses 28 and 2b
+   ```
+
+4. **Test the library:**
+   ```bash
+   python3 -c "import pianohat; print(pianohat.__version__)"
+   # Should print: 0.2.0
+   ```
+
+5. **Run an example:**
+   ```bash
+   cd ~/pianohat-examples  # or wherever examples are installed
+   python3 buttons.py
+   ```
+
+## Common Issues
+
+### "ImportError: No module named pianohat"
+
+**Solution:** Make sure you're using Python 3:
+```bash
+python3 your_script.py  # Not just 'python'
+```
+
+### "ImportError: No module named cap1xxx"
+
+**Solution:** Install the cap1xxx dependency:
+```bash
+pip3 install cap1xxx
+```
+
+### I2C devices not detected
+
+**Solution:** 
+1. Enable I2C in `raspi-config`
+2. Reboot: `sudo reboot`
+3. Check connection of Piano HAT
+
+### NetworkManager was removed (old installer issue)
+
+If the old installer removed NetworkManager and bricked your headless Pi:
+
+1. Boot with keyboard/monitor or from another system
+2. Reinstall NetworkManager:
+   ```bash
+   sudo apt-get update
+   sudo apt-get install network-manager
+   ```
+
+## Getting Help
+
+- **Issues:** https://github.com/pimoroni/piano-hat/issues
+- **Documentation:** https://github.com/pimoroni/piano-hat
+- **Forums:** https://forums.pimoroni.com
+
+## Benefits of Upgrading
+
+- ✅ No more system-breaking installers
+- ✅ Support for modern Raspberry Pi OS
+- ✅ 64-bit Raspberry Pi OS support
+- ✅ Better error messages
+- ✅ Type hints for IDE autocomplete
+- ✅ Actively maintained
+- ✅ Modern Python packaging
+- ✅ CI/CD with automated testing

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,15 +1,28 @@
-# Migration Guide: v0.1.0 to v0.2.0
+# Migration Guide: v0.1.0 to v0.3.x
 
-This guide helps you migrate from the old Piano HAT library (v0.1.0) to the modernized v0.2.0.
+This guide helps you migrate from the old Piano HAT library (v0.1.0) to the modernized v0.3.x.
 
 ## What Changed?
+
+### Major: New Driver Library
+
+**v0.1.0 & v0.2.x:**
+- Used `cap1xxx` library with GPIO interrupt-based button detection
+- Required GPIO pin access (pins 4 and 27)
+- **Broken on modern Raspberry Pi OS Bookworm** due to GPIO interface changes
+
+**v0.3.x:**
+- Uses actively-maintained `adafruit-circuitpython-cap1188` library
+- Polling-based button detection (no GPIO interrupts)
+- Works perfectly on modern Raspberry Pi OS (Bookworm, 64-bit)
+- No GPIO pin configuration needed
 
 ### Python Version
 
 **Old (v0.1.0):**
 - Supported Python 2.7 and Python 3.x
 
-**New (v0.2.0):**
+**New (v0.3.x):**
 - **Requires Python 3.7 or higher**
 - Python 2.7 is no longer supported
 
@@ -21,7 +34,7 @@ This guide helps you migrate from the old Piano HAT library (v0.1.0) to the mode
 curl https://get.pimoroni.com/pianohat | bash
 ```
 
-**New (v0.2.0):**
+**New (v0.3.x):**
 ```bash
 # Safe, modern installer
 curl -sSL https://raw.githubusercontent.com/pimoroni/piano-hat/master/install.sh | bash
@@ -35,7 +48,7 @@ pip3 install pianohat
 **Old (v0.1.0):**
 - Used `setup.py` for packaging
 
-**New (v0.2.0):**
+**New (v0.3.0):**
 - Uses `pyproject.toml` (PEP 517/518)
 - Supports editable installs: `pip install -e .`
 
@@ -50,13 +63,27 @@ Your existing code will work without modification:
 ```python
 import pianohat
 
-pianohat.auto_leds(True)
-
 def handle_note(channel, pressed):
     print(f"Note {channel} {'pressed' if pressed else 'released'}")
 
 pianohat.on_note(handle_note)
 ```
+
+### LED Control
+
+LED control is still supported in v0.3.x and is handled directly by the CAP1188 chips.
+
+```python
+# Link LEDs to touches (default behavior)
+pianohat.auto_leds(True)
+
+# Manual LED control
+pianohat.auto_leds(False)
+pianohat.set_led(0, True)
+pianohat.set_led_ramp_rate(250, 250)
+```
+
+If your LEDs do not respond, check that I2C is enabled and the Piano HAT is seated correctly.
 
 ### Python 3 Updates (if migrating from Python 2)
 
@@ -87,10 +114,12 @@ result = 10 / 3   # Returns 3.333... (regular division)
 
 **Old (v0.1.0):**
 - Designed for 32-bit Raspbian Jessie/Stretch
+- GPIO interrupts required
 
-**New (v0.2.0):**
+**New (v0.3.x):**
 - Supports Raspberry Pi OS Bullseye (11) and Bookworm (12)
 - Works on both 32-bit (armhf) and 64-bit (aarch64)
+- **No GPIO configuration needed**
 
 ### I2C Setup
 
@@ -103,11 +132,8 @@ sudo raspi-config
 
 Or check your config file:
 ```bash
-# On older systems:
-grep "dtparam=i2c_arm=on" /boot/config.txt
-
-# On newer systems (Bookworm+):
-grep "dtparam=i2c_arm=on" /boot/firmware/config.txt
+# On all systems:
+grep "dtparam=i2c_arm=on" /boot/firmware/config.txt /boot/config.txt 2>/dev/null
 ```
 
 ## Uninstalling Old Version
@@ -116,8 +142,7 @@ If you have the old version installed:
 
 ```bash
 # Remove old pip packages
-sudo pip uninstall pianohat
-sudo pip3 uninstall pianohat
+pip uninstall pianohat cap1xxx
 
 # Remove old apt packages (if any)
 sudo apt-get remove python-pianohat python3-pianohat
@@ -142,13 +167,21 @@ chmod +x install.sh
 ```bash
 # System dependencies
 sudo apt-get update
-sudo apt-get install python3-pip python3-dev i2c-tools python3-smbus
+sudo apt-get install python3-pip python3-dev i2c-tools
 
 # Install library
 pip3 install pianohat
 
 # Install example dependencies (optional)
 pip3 install pygame numpy
+```
+
+### Option 3: From source
+
+```bash
+git clone https://github.com/pimoroni/piano-hat
+cd piano-hat/library
+pip3 install -e .
 ```
 
 ## Testing the Migration
@@ -162,7 +195,7 @@ pip3 install pygame numpy
 2. **Verify installation:**
    ```bash
    pip3 show pianohat
-   # Should show version 0.2.0 or higher
+   # Should show version 0.3.1 or higher
    ```
 
 3. **Test I2C:**
@@ -174,7 +207,7 @@ pip3 install pygame numpy
 4. **Test the library:**
    ```bash
    python3 -c "import pianohat; print(pianohat.__version__)"
-   # Should print: 0.2.0
+   # Should print: 0.3.1
    ```
 
 5. **Run an example:**
@@ -192,16 +225,18 @@ pip3 install pygame numpy
 python3 your_script.py  # Not just 'python'
 ```
 
-### "ImportError: No module named cap1xxx"
+### "ImportError: No module named adafruit_cap1188"
 
-**Solution:** Install the cap1xxx dependency:
+**Solution:** Install the library:
 ```bash
-pip3 install cap1xxx
+pip3 install pianohat
+# or
+pip3 install adafruit-circuitpython-cap1188
 ```
 
 ### I2C devices not detected
 
-**Solution:** 
+**Solution:**
 1. Enable I2C in `raspi-config`
 2. Reboot: `sudo reboot`
 3. Check connection of Piano HAT
@@ -217,19 +252,30 @@ If the old installer removed NetworkManager and bricked your headless Pi:
    sudo apt-get install network-manager
    ```
 
-## Getting Help
+## What's New in v0.3.x?
 
-- **Issues:** https://github.com/pimoroni/piano-hat/issues
-- **Documentation:** https://github.com/pimoroni/piano-hat
-- **Forums:** https://forums.pimoroni.com
+✨ **Key Improvements:**
+- ✅ Works on modern Raspberry Pi OS (Bookworm, 64-bit)
+- ✅ No GPIO interrupt issues
+- ✅ Actively maintained Adafruit library
+- ✅ Polling-based detection (no complex GPIO wiring needed)
+- ✅ Works in virtual environments without special setup
+- ✅ 100% backward API compatible
 
 ## Benefits of Upgrading
 
 - ✅ No more system-breaking installers
-- ✅ Support for modern Raspberry Pi OS
+- ✅ Support for modern Raspberry Pi OS  
 - ✅ 64-bit Raspberry Pi OS support
 - ✅ Better error messages
 - ✅ Type hints for IDE autocomplete
 - ✅ Actively maintained
 - ✅ Modern Python packaging
 - ✅ CI/CD with automated testing
+- ✅ **Actually works with button detection!**
+
+## Getting Help
+
+- **Issues:** https://github.com/pimoroni/piano-hat/issues
+- **Documentation:** https://github.com/pimoroni/piano-hat
+- **Forums:** https://forums.pimoroni.com

--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -1,0 +1,209 @@
+# Piano HAT Modernization Summary
+
+This document summarizes the modernization work done on the Piano HAT library.
+
+## Overview
+
+The Piano HAT library has been completely modernized for use with current Raspberry Pi OS and Python 3.7+. The old installation script had serious issues including:
+- Removing NetworkManager (bricking headless systems)
+- Using deprecated Python 2.7
+- Hard-coded 32-bit (armhf) dependencies
+- Outdated package management
+
+## Changes Made
+
+### 1. Library Modernization (`library/`)
+
+#### `pyproject.toml` (NEW)
+- Modern PEP 517/518 packaging
+- Replaces old `setup.py`
+- Declares Python 3.7+ support
+- Proper dependency management
+- Optional example dependencies
+
+#### `pianohat.py` (UPDATED)
+- Added comprehensive type hints
+- Removed Python 2 compatibility code
+- Improved documentation strings
+- Better error messages
+- Code formatting improvements
+- Version bumped to 0.2.0
+
+### 2. Installation System
+
+#### `install.sh` (NEW)
+A safe, modern installer that:
+- Checks Python version (3.7+ required)
+- Verifies I2C is enabled
+- Installs system dependencies safely
+- Doesn't remove critical packages
+- Supports both 32-bit and 64-bit systems
+- Detects Piano HAT hardware
+- Provides clear error messages
+
+#### `requirements.txt` (NEW)
+- Core dependencies only
+- Clear, maintainable format
+
+#### `requirements-examples.txt` (NEW)
+- Optional dependencies for examples
+- Separate from core requirements
+
+### 3. Examples (Updated)
+
+All example files updated:
+- `buttons.py`
+- `simple-piano.py`
+- `leds.py`
+- `8bit-synth.py`
+- `midi-piano.py`
+- `learn-to-play.py`
+
+Changes:
+- Shebang changed to `#!/usr/bin/env python3`
+- pip install commands use `pip3` instead of `sudo pip`
+- Integer division fixed for Python 3 (`//` instead of `/`)
+
+### 4. Documentation
+
+#### `README.md` (UPDATED)
+- New "What's New" section
+- Compatibility information
+- Modern installation instructions
+- Simplified I2C enable instructions
+- Removed outdated references
+
+#### `CHANGELOG.md` (NEW)
+- Documents all changes
+- Follows Keep a Changelog format
+- Semantic versioning
+
+#### `CONTRIBUTING.md` (NEW)
+- Development setup guide
+- Code style guidelines
+- Pull request process
+- Testing procedures
+
+#### `MIGRATION.md` (NEW)
+- Upgrade guide from v0.1.0
+- Common issues and solutions
+- No breaking API changes!
+
+### 5. CI/CD
+
+#### `.github/workflows/python-package.yml` (NEW)
+- Automated testing on Python 3.7-3.12
+- Linting with flake8
+- Formatting checks with black
+- Type checking with mypy
+- Build verification
+
+#### `.github/workflows/publish.yml` (NEW)
+- Automated PyPI publishing on release
+- Package signing with Sigstore
+- GitHub Release integration
+
+## File Structure
+
+```
+Piano-HAT/
+├── .github/
+│   └── workflows/
+│       ├── python-package.yml    # CI/CD
+│       └── publish.yml            # PyPI publishing
+├── documentation/
+│   └── REFERENCE.md               # (unchanged)
+├── examples/
+│   ├── *.py                       # (all updated to Python 3)
+│   ├── README.md
+│   └── sounds/
+├── library/
+│   ├── pianohat.py               # (modernized with type hints)
+│   ├── pyproject.toml            # (NEW - modern packaging)
+│   ├── setup.py                  # (deprecated, but kept for compatibility)
+│   └── ...
+├── CHANGELOG.md                   # (NEW)
+├── CONTRIBUTING.md               # (NEW)
+├── MIGRATION.md                  # (NEW)
+├── README.md                     # (updated)
+├── install.sh                    # (NEW - safe installer)
+├── requirements.txt              # (NEW)
+└── requirements-examples.txt     # (NEW)
+```
+
+## Compatibility
+
+### Supported
+✅ Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12+
+✅ Raspberry Pi OS Bullseye (11)
+✅ Raspberry Pi OS Bookworm (12)
+✅ 32-bit (armhf) architecture
+✅ 64-bit (aarch64) architecture
+✅ All Pi models with 40-pin GPIO
+
+### Not Supported
+❌ Python 2.7
+❌ Python 3.6 and earlier
+❌ Old Raspbian Jessie/Stretch
+
+## API Compatibility
+
+**100% backward compatible!** No code changes required for existing applications.
+
+## Testing Checklist
+
+### Before Pull Request
+
+- [ ] Library imports successfully
+- [ ] Type checking passes (mypy)
+- [ ] Linting passes (flake8)
+- [ ] Formatting is correct (black)
+- [ ] Install script runs without errors
+- [ ] Examples run without errors (if hardware available)
+- [ ] I2C detection works
+- [ ] Documentation is accurate
+
+### Hardware Testing (if available)
+
+- [ ] All 13 piano keys respond
+- [ ] Octave up/down buttons work
+- [ ] Instrument button works
+- [ ] LEDs control works
+- [ ] Auto LEDs work
+- [ ] Event handlers trigger correctly
+
+## Benefits
+
+1. **System Safety:** New installer won't break your system
+2. **Modern Support:** Works with current Raspberry Pi OS
+3. **64-bit Ready:** Full support for 64-bit systems
+4. **Better DX:** Type hints, better errors, modern tooling
+5. **Maintainable:** CI/CD, automated testing, clear docs
+6. **Future-proof:** Modern packaging standards
+
+## Known Issues / Limitations
+
+1. Hardware testing not performed (requires actual Piano HAT)
+2. MIDI example may need additional testing
+3. pygame/numpy availability varies by platform
+
+## Next Steps for Pull Request
+
+1. **Test on actual hardware** (important!)
+2. **Verify installer** on fresh Raspberry Pi OS
+3. **Run all examples** to ensure they work
+4. **Check CI/CD** workflows pass
+5. **Create PR** with detailed description
+
+## Credits
+
+Modernization by: [Your Name/Username]
+Original library by: Philip Howard (Pimoroni)
+License: MIT
+
+## Notes
+
+- All changes maintain API compatibility
+- No breaking changes to user code
+- Old `setup.py` kept for legacy compatibility
+- Can be deployed to PyPI when ready

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,26 +2,25 @@
 
 Get your Piano HAT up and running in minutes!
 
+**Piano HAT v0.2.0 uses the cap1xxx library for modern Python 3 support on Raspberry Pi OS Bookworm.**
+
 ## Prerequisites
 
 - Raspberry Pi (any model with 40-pin GPIO header)
-- Raspberry Pi OS (Bullseye or Bookworm recommended)
-- Piano HAT properly connected
+- Raspberry Pi OS Bullseye or Bookworm (32-bit or 64-bit)
+- Piano HAT properly connected to GPIO header
 - Internet connection
+- Python 3.7 or higher
 
 ## Installation (Choose One Method)
 
-### Method 1: Quick Install (Recommended)
+### Method 1: From Scratch (Recommended for new installations)
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/pimoroni/piano-hat/master/install.sh | bash
-```
+# Install system dependencies
+sudo apt-get update
+sudo apt-get install -y python3 git python3-dev python3-smbus i2c-tools
 
-When prompted, choose `Y` to install examples.
-
-### Method 2: Manual Install
-
-```bash
 # Enable I2C
 sudo raspi-config
 # Navigate to: Interface Options → I2C → Enable
@@ -29,20 +28,45 @@ sudo raspi-config
 # Reboot
 sudo reboot
 
-# Install
-sudo apt-get update
-sudo apt-get install python3-pip i2c-tools python3-smbus
-pip3 install pianohat
+# Clone repository
+git clone https://github.com/pimoroni/piano-hat.git
+cd piano-hat
+
+# Create virtual environment with system site packages
+python3 -m venv --system-site-packages venv
+source venv/bin/activate
+
+# Run installer
+./install.sh
 ```
+
+When prompted, choose `Y` to install examples.
+
+### Method 2: Quick Install (Alternative)
+
+```bash
+curl -sSL https://raw.githubusercontent.com/pimoroni/piano-hat/master/install.sh | bash
+```
+
+**Note:** The installer automatically handles virtual environment creation and installs required system packages (python3-dev, python3-smbus, i2c-tools).
 
 ## Verify Installation
 
 ```bash
 # Check I2C devices (should show 28 and 2b)
-i2cdetect -y 1
+sudo i2cdetect -y 1
 
-# Test library import
-python3 -c "import pianohat; print('Piano HAT v' + pianohat.__version__)"
+# Test library import (make sure venv is activated if you used one)
+python3 -c "import pianohat; print('Piano HAT ready!')"
+```
+
+**I2C Addresses:**
+- `0x28` - CAP1188 chip for keys C through G (indices 0-7)
+- `0x2b` - CAP1188 chip for keys G# through C (indices 8-15)
+
+**Note:** If you installed using a virtual environment, remember to activate it first:
+```bash
+source venv/bin/activate  # or wherever you created your venv
 ```
 
 ## Your First Program
@@ -58,7 +82,8 @@ import pianohat
 print("Touch the Piano HAT keys!")
 print("Press Ctrl+C to exit")
 
-# Enable automatic LEDs
+# Enable automatic LEDs (links LEDs to touches)
+# Use auto_leds(False) + set_led() for manual control.
 pianohat.auto_leds(True)
 
 # Handle note presses
@@ -120,8 +145,30 @@ python3 simple-piano.py
 
 ### "No module named 'pianohat'"
 ```bash
-# Use python3, not python
+# Make sure virtual environment is activated
+source venv/bin/activate
+
+# Or use python3 if installed system-wide
 python3 your_script.py
+```
+
+### "No module named 'smbus'"
+```bash
+# Install system package (required even in venv)
+sudo apt-get install python3-smbus
+
+# If using venv, recreate with --system-site-packages
+python3 -m venv --system-site-packages venv
+source venv/bin/activate
+```
+
+### "Python.h: No such file or directory"
+```bash
+# Install development headers
+sudo apt-get install python3-dev
+
+# Then retry installation
+./install.sh
 ```
 
 ### "No such file or directory: '/dev/i2c-1'"

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,157 @@
+# Quick Start Guide
+
+Get your Piano HAT up and running in minutes!
+
+## Prerequisites
+
+- Raspberry Pi (any model with 40-pin GPIO header)
+- Raspberry Pi OS (Bullseye or Bookworm recommended)
+- Piano HAT properly connected
+- Internet connection
+
+## Installation (Choose One Method)
+
+### Method 1: Quick Install (Recommended)
+
+```bash
+curl -sSL https://raw.githubusercontent.com/pimoroni/piano-hat/master/install.sh | bash
+```
+
+When prompted, choose `Y` to install examples.
+
+### Method 2: Manual Install
+
+```bash
+# Enable I2C
+sudo raspi-config
+# Navigate to: Interface Options → I2C → Enable
+
+# Reboot
+sudo reboot
+
+# Install
+sudo apt-get update
+sudo apt-get install python3-pip i2c-tools python3-smbus
+pip3 install pianohat
+```
+
+## Verify Installation
+
+```bash
+# Check I2C devices (should show 28 and 2b)
+i2cdetect -y 1
+
+# Test library import
+python3 -c "import pianohat; print('Piano HAT v' + pianohat.__version__)"
+```
+
+## Your First Program
+
+Create a file called `test.py`:
+
+```python
+#!/usr/bin/env python3
+
+import signal
+import pianohat
+
+print("Touch the Piano HAT keys!")
+print("Press Ctrl+C to exit")
+
+# Enable automatic LEDs
+pianohat.auto_leds(True)
+
+# Handle note presses
+def handle_note(channel, pressed):
+    if pressed:
+        print(f"Note {channel} pressed")
+    else:
+        print(f"Note {channel} released")
+
+# Handle octave buttons
+def handle_octave_up(channel, pressed):
+    if pressed:
+        print("Octave UP!")
+
+def handle_octave_down(channel, pressed):
+    if pressed:
+        print("Octave DOWN!")
+
+# Handle instrument button
+def handle_instrument(channel, pressed):
+    if pressed:
+        print("Instrument!")
+
+# Register event handlers
+pianohat.on_note(handle_note)
+pianohat.on_octave_up(handle_octave_up)
+pianohat.on_octave_down(handle_octave_down)
+pianohat.on_instrument(handle_instrument)
+
+# Wait for events
+signal.pause()
+```
+
+Run it:
+```bash
+chmod +x test.py
+python3 test.py
+```
+
+## Try the Examples
+
+If you installed with examples:
+
+```bash
+cd ~/pianohat-examples
+
+# Simple button test
+python3 buttons.py
+
+# LED animations
+python3 leds.py
+
+# Piano with sound (requires pygame)
+pip3 install pygame
+python3 simple-piano.py
+```
+
+## Common Issues
+
+### "No module named 'pianohat'"
+```bash
+# Use python3, not python
+python3 your_script.py
+```
+
+### "No such file or directory: '/dev/i2c-1'"
+```bash
+# Enable I2C
+sudo raspi-config
+# Interface Options → I2C → Enable
+sudo reboot
+```
+
+### No devices detected at 0x28 and 0x2b
+- Check Piano HAT is properly seated on GPIO pins
+- Verify I2C is enabled
+- Try: `sudo i2cdetect -y 1`
+
+## Next Steps
+
+- Read the [API Reference](documentation/REFERENCE.md)
+- Explore the [examples](examples/)
+- Build your own piano project!
+
+## Getting Help
+
+- [GitHub Issues](https://github.com/pimoroni/piano-hat/issues)
+- [Pimoroni Forums](https://forums.pimoroni.com)
+
+## Learn More
+
+- [Full README](README.md)
+- [Migration Guide](MIGRATION.md) (if upgrading)
+- [Contributing Guide](CONTRIBUTING.md) (to help develop)
+
+Enjoy your Piano HAT! 🎹

--- a/README.md
+++ b/README.md
@@ -8,52 +8,123 @@ Piano HAT is a tiny Pi piano with 16 touch-sensitive buttons. It features:
 * Octave Up/Down
 * Instrument Select
 
+## Compatibility
+
+This library supports:
+- **Python:** 3.7, 3.8, 3.9, 3.10, 3.11, 3.12+
+- **Raspberry Pi OS:** Bullseye (11), Bookworm (12), and newer
+- **Architecture:** Both 32-bit (armhf) and 64-bit (aarch64)
+- **Raspberry Pi Models:** All models with 40-pin GPIO header
+
+## What's New in v0.2.0
+
+- ✨ **Python 3 only** - Dropped Python 2.7 support
+- 🏗️ **Modern packaging** - Uses `pyproject.toml` instead of `setup.py`
+- 🎯 **Type hints** - Added type annotations for better IDE support
+- 📦 **Simplified install** - New installer that won't break your system
+- 🔧 **64-bit support** - Works on modern 64-bit Raspberry Pi OS
+- 📝 **Better documentation** - Updated examples and clearer instructions
+
 ## Installing
 
-### Full install (recommended):
+**Important:** This library has been modernized for Python 3.7+ and modern Raspberry Pi OS (both 32-bit and 64-bit).
 
-We've created an easy installation script that will install all pre-requisites and get your Piano HAT
-up and running with minimal efforts. To run it, fire up Terminal which you'll find in Menu -> Accessories -> Terminal
-on your Raspberry Pi desktop, as illustrated below:
+### Quick Install (Recommended):
 
-![Finding the terminal](http://get.pimoroni.com/resources/github-repo-terminal.png)
-
-In the new terminal window type the command exactly as it appears below (check for typos) and follow the on-screen instructions:
+Run this one-liner to install Piano HAT with all dependencies:
 
 ```bash
-curl https://get.pimoroni.com/pianohat | bash
+curl -sSL https://raw.githubusercontent.com/pimoroni/piano-hat/master/install.sh | bash
 ```
 
-If you choose to download examples you'll find them in `/home/pi/Pimoroni/pianohat/`.
-
-⚠ Note that on recent versions of Raspberry Pi OS, you may need to **enable I2C manually**. You can do this using the Raspberry Pi Configuration utility - find it in the 'Preferences' menu, or enter `sudo raspi-config` at a Terminal prompt. The option to enable I2C is under 'Interfaces'.
-
-### Manual install:
-
-#### Library install for Python 3:
-
-on Raspberry Pi OS:
+Or download and run the install script:
 
 ```bash
-sudo apt install python3-pianohat
+git clone https://github.com/pimoroni/piano-hat
+cd piano-hat
+chmod +x install.sh
+./install.sh --examples
 ```
 
-other environments: 
+**Note for modern Raspberry Pi OS (Bookworm+):** Due to PEP 668 externally-managed environments, you may need to use a virtual environment:
 
 ```bash
-python3 -m pip install pianohat
+# Create and activate a virtual environment
+python3 -m venv --system-site-packages ~/pianohat-env
+source ~/pianohat-env/bin/activate
+
+# Now run the installer
+./install.sh --examples
 ```
 
-### Development:
+The installer will:
+- Check your Python version (3.7+ required)
+- Install system dependencies (I2C tools, python3-smbus)
+- Install the pianohat library
+- Optionally install examples and their dependencies
 
-If you want to contribute, or like living on the edge of your seat by having the latest code, you should clone this repository, `cd` to the library directory, and run:
+### Manual Installation:
+
+#### Install System Dependencies:
 
 ```bash
-sudo python3 setup.py install
+sudo apt-get update
+sudo apt-get install python3-pip python3-dev i2c-tools python3-smbus
 ```
-(or `sudo python setup.py install` whichever your primary Python environment may be)
 
-In all cases you will have to enable the i2c bus.
+#### Install Library:
+
+Using pip:
+```bash
+pip3 install pianohat
+```
+
+From source:
+```bash
+git clone https://github.com/pimoroni/piano-hat
+cd piano-hat/library
+pip3 install .
+```
+
+#### Install Example Dependencies (Optional):
+
+```bash
+pip3 install pygame numpy
+```
+
+### Enable I2C:
+
+Piano HAT requires I2C to be enabled. On modern Raspberry Pi OS:
+
+```bash
+sudo raspi-config
+```
+
+Then navigate to: `Interface Options` → `I2C` → `Enable`
+
+Alternatively, check that this line exists in `/boot/config.txt` or `/boot/firmware/config.txt`:
+```
+dtparam=i2c_arm=on
+```
+
+After enabling I2C, reboot your Raspberry Pi.
+
+## Running Examples
+
+The example scripts demonstrate Piano HAT's capabilities:
+
+- **buttons.py** - Basic key press detection (no audio required)
+- **leds.py** - LED animation (no audio required)
+- **simple-piano.py** - Play piano sounds (requires audio device)
+- **8bit-synth.py** - Software synthesis (requires audio device)
+- **midi-piano.py** - MIDI output (requires MIDI software)
+- **learn-to-play.py** - Interactive tutorial (requires audio device)
+
+**Audio Requirements:** Examples that play sound require an audio output device. For headless setups, consider:
+- USB audio adapter
+- I2S audio HAT (e.g., [Pimoroni Audio boards](https://shop.pimoroni.com/collections/pimoroni-audio))
+- Configure audio over HDMI
+- SSH with X11 forwarding to a machine with audio
 
 ## Documentation & Support
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,31 @@ This library supports:
 - **Architecture:** Both 32-bit (armhf) and 64-bit (aarch64)
 - **Raspberry Pi Models:** All models with 40-pin GPIO header
 
-## What's New in v0.2.0
+## What's New in v0.3.1
 
-- ✨ **Python 3 only** - Dropped Python 2.7 support
-- 🏗️ **Modern packaging** - Uses `pyproject.toml` instead of `setup.py`
-- 🎯 **Type hints** - Added type annotations for better IDE support
-- 📦 **Simplified install** - New installer that won't break your system
-- 🔧 **64-bit support** - Works on modern 64-bit Raspberry Pi OS
-- 📝 **Better documentation** - Updated examples and clearer instructions
+- 🎯 **Fixed GPIO issues** - Replaced interrupt-based GPIO with polling to work on modern Bookworm
+- 📦 **Single dependency** - Now uses actively-maintained `adafruit-circuitpython-cap1188`
+- 💡 **LED control restored** - CAP1188 LED linking and manual control are supported
+- ✅ **Actually works** - Button detection finally works on Bookworm 64-bit systems
+- 🔧 **Simplified install** - No more GPIO configuration needed
+- 🧵 **Background polling** - Non-blocking button detection with proper debouncing
+
+## Version History
+
+**v0.3.1** (Latest):
+- Restored CAP1188 LED control (linking and manual on/off)
+- Lowered minimum CAP1188 dependency to match available PyPI versions
+
+**v0.3.0**:
+- Switched from cap1xxx to Adafruit CircuitPython library (fixing GPIO interrupt issues)
+- Button detection now works on modern Raspberry Pi OS Bookworm
+- Removed GPIO interrupt complexity, now uses polling
+- [Migration Guide: v0.2→v0.3](MIGRATION.md)
+
+**v0.2.0**:
+- Python 3 only (dropped Python 2.7 support)
+- Modern packaging with `pyproject.toml`
+- Type hints for IDE support
 
 ## Installing
 
@@ -59,7 +76,7 @@ source ~/pianohat-env/bin/activate
 
 The installer will:
 - Check your Python version (3.7+ required)
-- Install system dependencies (I2C tools, python3-smbus)
+- Install system dependencies (I2C tools)
 - Install the pianohat library
 - Optionally install examples and their dependencies
 
@@ -69,7 +86,7 @@ The installer will:
 
 ```bash
 sudo apt-get update
-sudo apt-get install python3-pip python3-dev i2c-tools python3-smbus
+sudo apt-get install python3-pip python3-dev i2c-tools
 ```
 
 #### Install Library:
@@ -109,6 +126,13 @@ dtparam=i2c_arm=on
 
 After enabling I2C, reboot your Raspberry Pi.
 
+### I2C Addresses
+
+Piano HAT uses two CAP1188 chips on the I2C bus:
+
+- `0x28` - keys C through G (indices 0-7)
+- `0x2b` - keys G# through C (indices 8-15)
+
 ## Running Examples
 
 The example scripts demonstrate Piano HAT's capabilities:
@@ -119,6 +143,8 @@ The example scripts demonstrate Piano HAT's capabilities:
 - **8bit-synth.py** - Software synthesis (requires audio device)
 - **midi-piano.py** - MIDI output (requires MIDI software)
 - **learn-to-play.py** - Interactive tutorial (requires audio device)
+
+**LED Control:** The LEDs are driven by the CAP1188 chips. Use `auto_leds(True)` to link LEDs to touches, or `auto_leds(False)` and `set_led()` for manual control.
 
 **Audio Requirements:** Examples that play sound require an audio output device. For headless setups, consider:
 - USB audio adapter

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,21 +1,27 @@
 # Installation Testing Checklist
 
-Use this checklist to verify the Piano HAT installation works correctly.
+Use this checklist to verify the Piano HAT installation works correctly on v0.3.x.
+
+**Key Changes in v0.3.x:**
+- Uses `adafruit-circuitpython-cap1188` (actively maintained CircuitPython library)
+- No longer requires GPIO interrupts (works on modern Bookworm)
+- `smbus` is no longer needed (Adafruit handles all dependencies)
 
 ## Pre-Installation Checks
 
 - [ ] Raspberry Pi model identified
-- [ ] Raspberry Pi OS version (run `cat /etc/os-release`)
+- [ ] Raspberry Pi OS Bullseye (11) or Bookworm (12)
+- [ ] Architecture noted (32-bit armhf or 64-bit aarch64)
 - [ ] Python version 3.7+ (run `python3 --version`)
 - [ ] I2C enabled (check `/boot/firmware/config.txt` or `/boot/config.txt`)
-- [ ] Piano HAT physically connected to GPIO pins
+- [ ] Piano HAT physically connected and I2C address visible (0x28, 0x2b)
 
 ## System Package Installation
 
 - [ ] `i2c-tools` installed (run `which i2cdetect`)
 - [ ] `python3-pip` installed (run `which pip3`)
 - [ ] `python3-dev` installed
-- [ ] `python3-smbus` installed (run `python3 -c "import smbus"` outside venv)
+- [ ] I2C bus visible with i2cdetect (run `i2cdetect -y 1`, should show 28 and 2b)
 
 ## Library Installation Tests
 
@@ -30,15 +36,15 @@ cd ~/piano-hat-test  # or wherever you cloned
 
 **Checklist:**
 - [ ] Virtual environment created successfully
-- [ ] Installer detected venv
+- [ ] Installer detected venv configuration
 - [ ] Skipped system package installation (expected in venv)
 - [ ] pip packages installed successfully
 - [ ] `pianohat` module importable
-- [ ] `cap1xxx` dependency installed
-- [ ] `smbus2` installed (or can access system `smbus`)
+- [ ] `adafruit-circuitpython-cap1188` dependency installed
+- [ ] `board` module accessible (Adafruit's I2C interface)
 - [ ] Examples copied to `~/pianohat-examples`
 
-### System-Wide Installation (Older OS)
+### System-Wide Installation (Not recommended on Bookworm due to PEP 668)
 
 ```bash
 ./install.sh --examples
@@ -47,7 +53,7 @@ cd ~/piano-hat-test  # or wherever you cloned
 **Checklist:**
 - [ ] System packages installed via apt
 - [ ] Python library installed via pip
-- [ ] No PEP 668 errors
+- [ ] No PEP 668 errors (if using Bookworm, venv recommended)
 - [ ] Examples copied
 
 ## Hardware Detection
@@ -70,7 +76,30 @@ python3 -c "import pianohat; print('Piano HAT v' + pianohat.__version__)"
 
 **Checklist:**
 - [ ] Import successful (no errors)
-- [ ] Version displays correctly (should be 0.2.0+)
+- [ ] Version displays correctly (should be 0.3.1+)
+
+## Button Detection Test (v0.3.x)
+
+**Important:** v0.3.x uses polling-based button detection (no GPIO interrupts). This is more reliable on modern systems.
+
+```bash
+# Test with driver_test.py (if available in repo)
+python3 driver_test.py
+```
+
+**Expected output:**
+```
+✓ CAP1188 at 0x28 detected
+✓ CAP1188 at 0x2b detected
+[timestamp] Button 0 (C) PRESSED
+[timestamp] Button 0 (C) RELEASED
+```
+
+**Checklist:**
+- [ ] Both CAP1188 chips detected
+- [ ] Button presses show timestamp and name
+- [ ] Debouncing working (no double-presses at 20ms interval)
+- [ ] All 16 buttons respond to touch
 
 ## Example Tests
 
@@ -127,7 +156,7 @@ python3 simple-piano.py
 **Solution:** Use a virtual environment (see above)
 
 ### "No module named 'smbus'" in venv
-**Solution:** `pip install smbus2` or use `--system-site-packages` when creating venv
+**Solution:** This is no longer needed in v0.3.0. If you see this, update the library: `pip install --upgrade pianohat`
 
 ### No I2C devices detected
 **Solution:** 
@@ -138,21 +167,38 @@ python3 simple-piano.py
 ### pygame errors on headless system
 **Solution:** This is expected. Use buttons.py or leds.py to test hardware.
 
-### "ImportError: cap1xxx"
-**Solution:** `pip install cap1xxx`
+### "ImportError: adafruit_circuitpython_cap1188"
+**Solution:** `pip install adafruit-circuitpython-cap1188`
+
+### Buttons not responding
+**Solution (v0.3.x):**
+- The new polling system requires 20ms per check cycle
+- Touch a button distinctly (hold for 50ms+)
+- Test with driver_test.py to verify hardware communication
+- Check I2C is enabled and working
 
 ## Success Criteria
 
-Minimum for successful install:
+**Minimum for successful install (v0.3.x):**
 - ✅ Library imports without errors
-- ✅ I2C devices detected
+- ✅ I2C devices detected (i2cdetect shows 0x28 and 0x2b)
+- ✅ Both CAP1188 chips detected and working
 - ✅ buttons.py works (detects key presses)
-- ✅ leds.py works (controls LEDs)
+- ✅ Adafruit CircuitPython library installed correctly
 
-Full success:
+**Full success:**
 - ✅ All of the above
+- ✅ driver_test.py shows debounced button presses
+- ✅ leds.py works (controls LEDs - should run without errors)
 - ✅ simple-piano.py plays sounds (if audio available)
-- ✅ Examples run without errors
+- ✅ All 16 buttons respond to touch
+- ✅ Octave and Instrument buttons work
+
+**Key Changes in v0.3.x:**
+- ✅ GPIO interrupts are no longer used (polling instead)
+- ✅ Works on modern Bookworm 64-bit systems
+- ✅ No GPIO pin conflicts
+- ✅ More reliable button detection
 
 ## Report Template
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,184 @@
+# Installation Testing Checklist
+
+Use this checklist to verify the Piano HAT installation works correctly.
+
+## Pre-Installation Checks
+
+- [ ] Raspberry Pi model identified
+- [ ] Raspberry Pi OS version (run `cat /etc/os-release`)
+- [ ] Python version 3.7+ (run `python3 --version`)
+- [ ] I2C enabled (check `/boot/firmware/config.txt` or `/boot/config.txt`)
+- [ ] Piano HAT physically connected to GPIO pins
+
+## System Package Installation
+
+- [ ] `i2c-tools` installed (run `which i2cdetect`)
+- [ ] `python3-pip` installed (run `which pip3`)
+- [ ] `python3-dev` installed
+- [ ] `python3-smbus` installed (run `python3 -c "import smbus"` outside venv)
+
+## Library Installation Tests
+
+### In Virtual Environment (Recommended for Bookworm+)
+
+```bash
+python3 -m venv --system-site-packages ~/pianohat-test
+source ~/pianohat-test/bin/activate
+cd ~/piano-hat-test  # or wherever you cloned
+./install.sh --examples
+```
+
+**Checklist:**
+- [ ] Virtual environment created successfully
+- [ ] Installer detected venv
+- [ ] Skipped system package installation (expected in venv)
+- [ ] pip packages installed successfully
+- [ ] `pianohat` module importable
+- [ ] `cap1xxx` dependency installed
+- [ ] `smbus2` installed (or can access system `smbus`)
+- [ ] Examples copied to `~/pianohat-examples`
+
+### System-Wide Installation (Older OS)
+
+```bash
+./install.sh --examples
+```
+
+**Checklist:**
+- [ ] System packages installed via apt
+- [ ] Python library installed via pip
+- [ ] No PEP 668 errors
+- [ ] Examples copied
+
+## Hardware Detection
+
+```bash
+# Should show devices at 0x28 and 0x2b
+i2cdetect -y 1
+```
+
+**Checklist:**
+- [ ] I2C bus 1 accessible
+- [ ] Device at address 0x28 detected (first CAP1188)
+- [ ] Device at address 0x2b detected (second CAP1188)
+
+## Library Import Test
+
+```bash
+python3 -c "import pianohat; print('Piano HAT v' + pianohat.__version__)"
+```
+
+**Checklist:**
+- [ ] Import successful (no errors)
+- [ ] Version displays correctly (should be 0.2.0+)
+
+## Example Tests
+
+### buttons.py (No audio required)
+
+```bash
+cd ~/pianohat-examples
+python3 buttons.py
+```
+
+**Test:**
+- [ ] Script runs without errors
+- [ ] Touch each piano key (C through C)
+- [ ] Key presses appear in terminal
+- [ ] Touch octave up/down buttons
+- [ ] Touch instrument button
+- [ ] LED lights when key touched (if auto_leds enabled)
+- [ ] Press Ctrl+C to exit cleanly
+
+### leds.py (No audio required)
+
+```bash
+python3 leds.py
+```
+
+**Test:**
+- [ ] Script runs without errors
+- [ ] LEDs animate in sequence
+- [ ] All 16 LEDs light up
+- [ ] Press Ctrl+C to exit cleanly
+
+### simple-piano.py (Requires audio)
+
+```bash
+python3 simple-piano.py
+```
+
+**Test:**
+- [ ] Script runs without errors
+- [ ] pygame initializes
+- [ ] Sounds load from `sounds/piano/` directory
+- [ ] Pressing keys plays piano sounds
+- [ ] Octave up/down buttons work
+- [ ] Press Ctrl+C to exit cleanly
+
+**If audio fails:**
+- [ ] Check audio device available: `aplay -l`
+- [ ] Test audio: `speaker-test -t wav -c 2`
+- [ ] Configure alsa if needed
+
+## Common Issues
+
+### "externally-managed-environment" error
+**Solution:** Use a virtual environment (see above)
+
+### "No module named 'smbus'" in venv
+**Solution:** `pip install smbus2` or use `--system-site-packages` when creating venv
+
+### No I2C devices detected
+**Solution:** 
+1. Enable I2C: `sudo raspi-config` → Interface Options → I2C
+2. Reboot: `sudo reboot`
+3. Check Piano HAT is properly seated on GPIO pins
+
+### pygame errors on headless system
+**Solution:** This is expected. Use buttons.py or leds.py to test hardware.
+
+### "ImportError: cap1xxx"
+**Solution:** `pip install cap1xxx`
+
+## Success Criteria
+
+Minimum for successful install:
+- ✅ Library imports without errors
+- ✅ I2C devices detected
+- ✅ buttons.py works (detects key presses)
+- ✅ leds.py works (controls LEDs)
+
+Full success:
+- ✅ All of the above
+- ✅ simple-piano.py plays sounds (if audio available)
+- ✅ Examples run without errors
+
+## Report Template
+
+When reporting issues, include:
+
+```
+**Hardware:**
+- Raspberry Pi Model: 
+- Piano HAT connected: Yes/No
+- Other HATs/devices: 
+
+**Software:**
+- OS: (output of `cat /etc/os-release`)
+- Python: (output of `python3 --version`)
+- pianohat version: (output of `pip show pianohat`)
+- Installation method: [venv / system-wide]
+
+**I2C Detection:**
+(paste output of `i2cdetect -y 1`)
+
+**Error:**
+(paste full error message and traceback)
+
+**What works:**
+- [ ] buttons.py
+- [ ] leds.py
+- [ ] simple-piano.py
+- [ ] Other: ___________
+```

--- a/curl-pianohat-script.txt
+++ b/curl-pianohat-script.txt
@@ -1,0 +1,1000 @@
+#!/bin/bash
+
+: <<'DISCLAIMER'
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+This script is licensed under the terms of the MIT license.
+Unless otherwise noted, code reproduced herein
+was written for this script.
+
+- The Pimoroni Crew -
+
+DISCLAIMER
+
+# script control variables
+
+productname="Piano HAT" # the name of the product to install
+scriptname="pianohat" # the name of this script
+spacereq=50 # minimum size required on root partition in MB
+debugmode="no" # whether the script should use debug routines
+debuguser="none" # optional test git user to use in debug mode
+debugpoint="none" # optional git repo branch or tag to checkout
+forcesudo="no" # whether the script requires to be ran with root privileges
+promptreboot="no" # whether the script should always prompt user to reboot
+mininstall="no" # whether the script enforces minimum install routine
+customcmd="no" # whether to execute commands specified before exit
+gpioreq="yes" # whether low-level gpio access is required
+i2creq="yes" # whether the i2c interface is required
+i2sreq="no" # whether the i2s interface is required
+spireq="no" # whether the spi interface is required
+uartreq="no" # whether uart communication is required
+armhfonly="yes" # whether the script is allowed to run on other arch
+armv6="yes" # whether armv6 processors are supported
+armv7="yes" # whether armv7 processors are supported
+armv8="yes" # whether armv8 processors are supported
+raspbianonly="no" # whether the script is allowed to run on other OSes
+osreleases=( "Raspbian" "Kano" "Mate" "PiTop" "RetroPie" ) # list os-releases supported
+oswarning=( "OSMC" "Volumio" ) # list experimental os-releases
+osdeny=( "Darwin" "Debian" "Ubuntu" "Kali" "Linaro" ) # list os-releases specifically disallowed
+debpackage="pianohat" # the name of the package in apt repo
+piplibname="pianohat" # the name of the lib in pip repo
+pipoverride="no" # whether the script should give priority to pip repo
+pip2support="no" # whether python2 is supported
+pip3support="yes" # whether python3 is supported
+topdir="Pimoroni" # the name of the top level directory
+localdir="pianohat" # the name of the dir for copy of resources
+gitreponame="piano-hat" # the name of the git project repo
+gitusername="pimoroni" # the name of the git user to fetch repo from
+gitrepobranch="master" # repo branch to checkout
+gitrepotop="root" # the name of the dir to base repo from
+gitrepoclone="no" # whether the git repo is to be cloned locally
+gitclonedir="source" # the name of the local dir for repo
+repoclean="no" # whether any git repo clone found should be cleaned up
+repoinstall="no" # whether the library should be installed from repo
+libdir="library" # subdirectory of library in repo
+copydir=( "documentation" "examples" ) # subdirectories to copy from repo
+copyhead="no" # whether to use the latest repo commit or release tag
+pkgremove=() # list of conflicting packages to remove
+coredeplist=() # list of core dependencies
+pythondep=( "cap1xxx" ) # list of python dependencies
+pipdeplist=() # list of dependencies to source from pypi
+examplesdep=( "numpy" "pygame" ) # list of python modules required by examples
+somemoredep=() # list of additional dependencies
+xdisplaydep=() # list of dependencies requiring X server
+
+# template 1712181300
+
+FORCE=$1
+ASK_TO_REBOOT=false
+CURRENT_SETTING=false
+MIN_INSTALL=false
+FAILED_PKG=false
+REMOVE_PKG=false
+UPDATE_DB=false
+
+AUTOSTART=~/.config/lxsession/LXDE-pi/autostart
+BOOTCMD=/boot/cmdline.txt
+CONFIG=/boot/config.txt
+DTBODIR=/boot/overlays
+APTSRC=/etc/apt/sources.list
+INITABCONF=/etc/inittab
+BLACKLIST=/etc/modprobe.d/raspi-blacklist.conf
+LOADMOD=/etc/modules
+
+RASPOOL="http://mirrordirector.raspbian.org/raspbian/pool"
+RPIPOOL="http://archive.raspberrypi.org/debian/pool"
+DEBPOOL="http://ftp.debian.org/debian/pool"
+GETPOOL="https://get.pimoroni.com"
+
+SMBUS2="python-smbus_3.1.1+svn-2_armhf.deb"
+SMBUS3="python3-smbus_3.1.1+svn-2_armhf.deb"
+SMBUS35="python3-smbus1_1.1+35dbg-1_armhf.deb"
+
+SPIDEV2="python-spidev_2.0~git20150907_armhf.deb"
+SPIDEV3="python3-spidev_2.0~git20150907_armhf.deb"
+
+RPIGPIO1="raspi-gpio_0.20170105_armhf.deb"
+RPIGPIO2="python-rpi.gpio_0.6.3~jessie-1_armhf.deb"
+RPIGPIO3="python3-rpi.gpio_0.6.3~jessie-1_armhf.deb"
+
+export PIP_FORMAT=columns
+
+# function define
+
+confirm() {
+    if [ "$FORCE" == '-y' ]; then
+        true
+    else
+        read -r -p "$1 [y/N] " response < /dev/tty
+        if [[ $response =~ ^(yes|y|Y)$ ]]; then
+            true
+        else
+            false
+        fi
+    fi
+}
+
+prompt() {
+        read -r -p "$1 [y/N] " response < /dev/tty
+        if [[ $response =~ ^(yes|y|Y)$ ]]; then
+            true
+        else
+            false
+        fi
+}
+
+success() {
+    echo -e "$(tput setaf 2)$1$(tput sgr0)"
+}
+
+inform() {
+    echo -e "$(tput setaf 6)$1$(tput sgr0)"
+}
+
+warning() {
+    echo -e "$(tput setaf 1)$1$(tput sgr0)"
+}
+
+newline() {
+    echo ""
+}
+
+progress() {
+    count=0
+    until [ $count -eq 7 ]; do
+        echo -n "..." && sleep 1
+        ((count++))
+    done;
+    if ps -C $1 > /dev/null; then
+        echo -en "\r\e[K" && progress $1
+    fi
+}
+
+sudocheck() {
+    if [ $(id -u) -ne 0 ]; then
+        echo -e "Install must be run as root. Try 'sudo ./$scriptname'\n"
+        exit 1
+    fi
+}
+
+sysclean() {
+    sudo apt-get clean && sudo apt-get autoclean
+    sudo apt-get -y autoremove &> /dev/null
+}
+
+sysupdate() {
+    if ! $UPDATE_DB; then
+        echo "Updating apt indexes..." && progress apt-get &
+        sudo apt-get update 1> /dev/null || { warning "Apt failed to update indexes!" && exit 1; }
+        sleep 3 && UPDATE_DB=true
+    fi
+}
+
+sysupgrade() {
+    sudo apt-get upgrade
+    sudo apt-get clean && sudo apt-get autoclean
+    sudo apt-get -y autoremove &> /dev/null
+}
+
+sysreboot() {
+    warning "Some changes made to your system require"
+    warning "your computer to reboot to take effect."
+    echo
+    if prompt "Would you like to reboot now?"; then
+        sync && sudo reboot
+    fi
+}
+
+home_dir() {
+    if [ $EUID -ne 0 ]; then
+        USER_HOME=$(getent passwd $USER | cut -d: -f6)
+    else
+        warning "Running as root, please log in as a regular user with sudo rights!"
+        echo && exit 1
+    fi
+}
+
+space_chk() {
+    if command -v stat > /dev/null; then
+        if [ $spacereq -gt $(($(stat -f -c "%a*%S" /)/10**6)) ];then
+            echo
+            warning  "There is not enough space left to proceed with  installation"
+            if confirm "Would you like to attempt to expand your filesystem?"; then
+                curl -sS $GETPOOL/expandfs | sudo bash && exit 1
+            else
+                echo && exit 1
+            fi
+        fi
+    fi
+}
+
+timestamp() {
+    date +%Y%m%d-%H%M
+}
+
+check_network() {
+        sudo ping -q -w 10 -c 1 1.1.1.1 | grep "received, 0" &> /dev/null
+        if [ $? -eq 0 ]; then
+                return 0
+        else
+                sudo ping -q -w 10 -c 1 8.8.8.8 | grep "received, 0" &> /dev/null
+                if [ $? -eq 0 ]; then
+                        return 0
+                fi
+        fi
+        return 1
+}
+
+launch_url() {
+    check_network || (error_box "You don't appear to be connected to the internet, please check your connection and try again!" && exit 1)
+    if command -v xdg-open > /dev/null; then
+        xdg-open "$1" && return 0
+    else
+        error_box "There was an error attempting to launch your browser!"
+    fi
+}
+
+get_install() {
+    check_network || (error_box "You don't appear to be connected to the internet, please check your connection and try again!" && exit 1)
+    if [ "$1" != diagnostic ];then
+        sysupdate && UPDATE_DB=true
+    fi
+    if ! command -v curl > /dev/null; then
+        apt_pkg_install "curl"
+    fi
+    curl -sS https://get.pimoroni.com/$1 | bash -s - "-y" $2
+    read -p "Press Enter to continue..." < /dev/tty
+}
+
+apt_pkg_req() {
+    APT_CHK=$(dpkg-query -W -f='${Status}\n' "$1" 2> /dev/null | grep "install ok installed")
+
+    if [ "" == "$APT_CHK" ]; then
+        echo "$1 is required"
+        true
+    else
+        echo "$1 is already installed"
+        false
+    fi
+}
+
+apt_pkg_install() {
+    echo "Installing $1..."
+    sudo apt-get --yes install "$1" 1> /dev/null || { inform "Apt failed to install $1!\nFalling back on pypi..." && return 1; }
+}
+
+apt_deb_chk() {
+    BEFORE=$(dpkg-query -W "$1" 2> /dev/null)
+    sudo apt-get --yes install "$1" &> /dev/null || return 1
+    AFTER=$(dpkg-query -W "$1" 2> /dev/null)
+    if [ "$BEFORE" == "$AFTER" ]; then
+        echo "$1 is already the newest version"
+    else
+        echo "$1 was successfully upgraded"
+    fi
+}
+
+apt_deb_install() {
+    echo "Installing $1..."
+    if [[ "$1" != *".deb"* ]]; then
+        sudo apt-get --yes install "$1" &> /dev/null || inform "Apt failed to install $1!\nFalling back on pypi..."
+        dpkg-query -W -f='${Status}\n' "$1" 2> /dev/null | grep "install ok installed"
+    else
+        DEBDIR=`mktemp -d /tmp/pimoroni.XXXXXX`
+        cd $DEBDIR
+        wget "$GETPOOL/resources/$1" &> /dev/null
+        sudo dpkg -i "$DEBDIR/$1" | grep "Installing $1"
+    fi
+}
+
+pip_cmd_chk() {
+    if command -v pip2 > /dev/null; then
+        PIP2_BIN="pip2"
+    elif command -v pip-2.7 > /dev/null; then
+        PIP2_BIN="pip-2.7"
+    elif command -v pip-2.6 > /dev/null; then
+        PIP2_BIN="pip-2.6"
+    else
+        PIP2_BIN="pip"
+    fi
+    if command -v pip3 > /dev/null; then
+        PIP3_BIN="pip3"
+    elif command -v pip-3.3 > /dev/null; then
+        PIP3_BIN="pip-3.3"
+    elif command -v pip-3.2 > /dev/null; then
+        PIP3_BIN="pip-3.2"
+    fi
+}
+
+pip2_lib_req() {
+    PIP2_CHK=$($PIP2_BIN list 2> /dev/null | grep -i "$1")
+
+    if [ -z "$PIP2_CHK" ]; then
+        true
+    else
+        false
+    fi
+}
+
+pip3_lib_req() {
+    PIP3_CHK=$($PIP3_BIN list 2> /dev/null | grep -i "$1")
+
+    if [ -z "$PIP3_CHK" ]; then
+        true
+    else
+        false
+    fi
+}
+
+usb_max_power() {
+    if grep -q "^max_usb_current=1$" $CONFIG; then
+        echo -e "\nMax USB current setting already active"
+    else
+        echo -e "\nAdjusting USB current setting in $CONFIG"
+        echo "max_usb_current=1" | sudo tee -a $CONFIG &> /dev/null
+    fi
+}
+
+add_dtoverlay() {
+    if grep -q "^dtoverlay=$1" $CONFIG; then
+        echo -e "\n$1 overlay already active"
+    elif grep -q "^#dtoverlay=$1" $CONFIG; then
+        sudo sed -i "/^#dtoverlay=$1$/ s|#||" $CONFIG
+        echo -e "\nAdding $1 overlay to $CONFIG"
+        ASK_TO_REBOOT=true
+    else
+        echo "dtoverlay=$1" | sudo tee -a $CONFIG &> /dev/null
+        echo -e "\nAdding $1 overlay to $CONFIG"
+        ASK_TO_REBOOT=true
+    fi
+}
+
+remove_dtoverlay() {
+    sudo sed -i "/^dtoverlay=$1$/ s|^|#|" $CONFIG
+    ASK_TO_REBOOT=true
+}
+
+enable_pi_audio() {
+    if grep -q "#dtparam=audio=on" $CONFIG; then
+        sudo sed -i "/^#dtparam=audio=on$/ s|#||" $CONFIG
+        echo -e "\nsnd_bcm2835 loaded (on-board audio enabled)"
+        ASK_TO_REBOOT=true
+    fi
+}
+
+disable_pi_audio() {
+    if grep -q "^dtparam=audio=on" $CONFIG; then
+        sudo sed -i "/^dtparam=audio=on$/ s|^|#|" $CONFIG
+        echo -e "\nsnd_bcm2835 unloaded (on-board audio disabled)"
+        ASK_TO_REBOOT=true
+    fi
+}
+
+test_audio() {
+    echo
+    if confirm "Do you wish to test your system now?"; then
+        echo -e "\nTesting..."
+        speaker-test -l5 -c2 -t wav
+    fi
+}
+
+disable_pulseaudio() {
+    sudo mv /etc/xdg/autostart/pulseaudio.desktop /etc/xdg/autostart/pulseaudio.disabled &> /dev/null
+    pulseaudio -k &> /dev/null
+}
+
+kill_volumealsa() {
+    sed -i "s|type=volumealsa|type=space|" $HOME/.config/lxpanel/LXDE/panels/panel &> /dev/null
+    sed -i "s|type=volumealsa|type=space|" $HOME/.config/lxpanel/LXDE-pi/panels/panel &> /dev/null
+}
+
+basic_asound() {
+        sudo echo -e "pcm.\041default {\n type hw\n card 1\n}" > $HOME/.asoundrc
+        sudo echo -e "ctl.\041default {\n type hw\n card 1\n}" >> $HOME/.asoundrc
+        sudo mv $HOME/.asoundrc /etc/asound.conf
+}
+
+config_set() {
+    if [ -n $defaultconf ]; then
+        sudo sed -i "s|$1=.*$|$1=$2|" $defaultconf
+    else
+        sudo sed -i "s|$1=.*$|$1=$2|" $3
+    fi
+}
+
+servd_trig() {
+    if command -v service > /dev/null; then
+        sudo service $1 $2
+    fi
+}
+
+get_init_sys() {
+    if command -v systemctl > /dev/null && systemctl | grep -q '\-\.mount'; then
+        SYSTEMD=1
+    elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
+        SYSTEMD=0
+    else
+        echo "Unrecognised init system" && exit 1
+    fi
+}
+
+i2c_vc_dtparam() {
+    if [ -e $CONFIG ] && grep -q "^dtparam=i2c_vc=on$" $CONFIG; then
+        echo -e "\ni2c0 bus already active"
+    else
+        echo -e "\nEnabling i2c0 bus in $CONFIG"
+        echo "dtparam=i2c_vc=on" | sudo tee -a $CONFIG && echo
+    fi
+}
+
+: <<'MAINSTART'
+
+Perform all variables declarations as well as function definition
+above this section for clarity, thanks!
+
+MAINSTART
+
+# intro message
+
+if [ $debugmode != "no" ]; then
+    if [ $debuguser != "none" ]; then
+        gitusername="$debuguser"
+    fi
+    if [ $debugpoint != "none" ]; then
+        gitrepobranch="$debugpoint"
+    fi
+    inform "\nDEBUG MODE ENABLED"
+    echo -e "git user $gitusername and $gitrepobranch branch/tag will be used\n"
+else
+    echo -e "\nThis script will install everything needed to use\n$productname"
+    if [ "$FORCE" != '-y' ]; then
+        inform "\nAlways be careful when running scripts and commands copied"
+        inform "from the internet. Ensure they are from a trusted source.\n"
+        warning "This script should -- only be run on a Raspberry Pi with RPi OS --"
+        warning "other systems and SBCs are not supported and may explode!\n"
+        echo -e "If you want to see what this script does before running it,"
+        echo -e "you should run: 'curl $GETPOOL/$scriptname'\n"
+    fi
+fi
+
+# checks and init
+space_chk
+home_dir
+
+if [ $debugmode != "no" ]; then
+    echo "USER_HOME is $USER_HOME"
+    echo "OS_NAME is $OS_NAME"
+    echo
+fi
+
+if [ $forcesudo == "yes" ]; then
+    sudocheck
+fi
+
+if [ $uartreq == "yes" ]; then
+    echo "Note: $productname requires UART communication"
+    warning "The serial console will be disabled if you proceed!"
+fi
+if [ $spireq == "yes" ]; then
+    echo -e "Note: $productname requires SPI communication"
+fi
+if [ $i2creq == "yes" ]; then
+    echo -e "Note: $productname requires I2C communication"
+fi
+if [ $i2sreq == "yes" ]; then
+    echo -e "Note: $productname uses the I2S interface"
+    if [ $OS_NAME != "Volumio" ]; then
+        warning "The on-board audio chip will be disabled if you proceed!"
+    fi
+fi
+
+newline
+if confirm "Do you wish to continue?"; then
+
+# basic environment preparation
+
+    echo -e "\nChecking environment..."
+
+    if [ "$FORCE" != '-y' ]; then
+        if ! check_network; then
+            warning "We can't connect to the Internet, check your network!" && exit 1
+        fi
+        sysupdate && newline
+    fi
+
+    if apt_pkg_req "apt-utils" &> /dev/null; then
+        apt_pkg_install "apt-utils"
+    fi
+    if ! command -v curl > /dev/null; then
+        apt_pkg_install "curl"
+    fi
+    if ! command -v wget > /dev/null; then
+        apt_pkg_install "wget"
+    fi
+
+    if [ "$pip2support" == "yes" ]; then
+        if ! [ -f "$(which python2)" ]; then
+            if confirm "Python 2 is not installed. Would like to install it?"; then
+                progress apt-get &
+                apt_pkg_install "python-pip"
+            else
+                pip2support="na"
+            fi
+        elif apt_pkg_req "python-pip" &> /dev/null; then
+            progress apt-get &
+            apt_pkg_install "python-pip"
+        fi
+    fi
+    if [ "$pip3support" == "yes" ]; then
+        if ! [ -f "$(which python3)" ]; then
+            if prompt "Python 3 is not installed. Would like to install it?"; then
+                progress apt-get &
+                apt_pkg_install "python3-pip"
+            else
+                pip3support="na"
+            fi
+        elif apt_pkg_req "python3-pip" &> /dev/null; then
+            progress apt-get &
+            apt_pkg_install "python3-pip"
+        fi
+    fi
+    pip_cmd_chk
+
+# hardware setup
+
+    echo -e "\nChecking hardware requirements..."
+
+    if [ $uartreq == "yes" ]; then
+        echo -e "\nThe serial console must be disabled for $productname to work"
+        curl -sS $GETPOOL/uarton | sudo bash -s - "-y" && ASK_TO_REBOOT=true
+    fi
+
+    if [ $gpioreq == "yes" ]; then
+        echo -e "\nChecking for packages required for GPIO control..."
+        if apt_pkg_req "raspi-gpio"; then
+            if ! apt_pkg_install "raspi-gpio" &> /dev/null; then
+                echo "package raspi-gpio can't be found, fetching from alternative location..."
+                DEBDIR=`mktemp -d /tmp/pimoroni.XXXXXX` && cd $DEBDIR
+                wget $RPIPOOL/main/r/raspi-gpio/$RPIGPIO1 &> /dev/null
+                sudo dpkg -i $DEBDIR/$RPIGPIO1 && FAILED_PKG=false
+            fi
+        fi
+        if [ "$pip2support" == "yes" ] && ! apt_pkg_install "python-rpi.gpio" &> /dev/null; then
+            if [ -n $(python --version 2>&1 | grep -q "2.7") ]; then
+                echo "package python-rpi.gpio can't be found, fetching from alternative location..."
+                DEBDIR=`mktemp -d /tmp/pimoroni.XXXXXX` && cd $DEBDIR
+                wget $RPIPOOL/main/r/rpi.gpio/$RPIGPIO2 &> /dev/null
+                sudo dpkg -i $DEBDIR/$RPIGPIO2 && FAILED_PKG=false
+            else
+                sudo $PIP2_BIN install RPi.GPIO && FAILED_PKG=false
+            fi
+        fi
+        if [ "$pip3support" == "yes" ] && ! apt_pkg_install "python3-rpi.gpio" &> /dev/null; then
+            if [ -n $(python3 --version 2>&1 | grep -q "3.4") ]; then
+                echo "package python3-rpi.gpio can't be found, fetching from alternative location..."
+                DEBDIR=`mktemp -d /tmp/pimoroni.XXXXXX` && cd $DEBDIR
+                wget $RPIPOOL/main/r/rpi.gpio/$RPIGPIO3 &> /dev/null
+                sudo dpkg -i $DEBDIR/$RPIGPIO3 && FAILED_PKG=false
+            else
+                sudo $PIP3_BIN install RPi.GPIO && FAILED_PKG=false
+            fi
+        fi
+        if [ "$pip2support" == "yes" ] && [ -f "$(which python2)" ]; then
+            if ! $PIP2_BIN list | grep "RPi.GPIO" &> /dev/null; then
+                warning "Unable to install RPi.GPIO for python 2!" && FAILED_PKG=true
+            else
+                RPIGPIO2="install ok installed"
+            fi
+        fi
+        if [ "$pip3support" == "yes" ] && [ -f "$(which python3)" ]; then
+            if ! $PIP3_BIN list | grep "RPi.GPIO" &> /dev/null; then
+                warning "Unable to install RPi.GPIO for python 3!" && FAILED_PKG=true
+            else
+                RPIGPIO3="install ok installed"
+            fi
+        fi
+        if [ "$RPIGPIO2" == "install ok installed" ] || [ "$RPIGPIO3" == "install ok installed" ]; then
+            if ! $FAILED_PKG; then
+                echo -e "RPi.GPIO installed and up-to-date"
+            fi
+        fi
+    fi
+
+    if [ $spireq == "yes" ]; then
+        newline
+        if ls /dev/spi* &> /dev/null; then
+            inform "SPI already enabled"
+        else
+            echo "SPI must be enabled for $productname to work"
+            if command -v raspi-config > /dev/null && sudo raspi-config nonint get_spi | grep -q "1"; then
+                sudo raspi-config nonint do_spi 0
+                inform "SPI is now enabled"
+            else
+                curl -sS $GETPOOL/spi | sudo bash -s - "-y" && ASK_TO_REBOOT=true
+            fi
+        fi
+        echo -e "\nChecking packages required by SPI interface..."
+        if [ "$pip2support" == "yes" ] && ! apt_pkg_install "python-spidev" &> /dev/null; then
+            if [ -n $(python --version 2>&1 | grep -q "2.7") ]; then
+                echo "package python-spidev can't be found, fetching from alternative location..."
+                DEBDIR=`mktemp -d /tmp/pimoroni.XXXXXX` && cd $DEBDIR
+                wget $RPIPOOL/main/s/spidev/$SPIDEV2 &> /dev/null
+                sudo dpkg -i $DEBDIR/$SPIDEV2 && FAILED_PKG=false
+            else
+                sudo $PIP2_BIN install spidev && FAILED_PKG=false
+            fi
+        fi
+        if [ "$pip3support" == "yes" ] && ! apt_pkg_install "python3-spidev" &> /dev/null; then
+            if [ -n $(python3 --version 2>&1 | grep -q "3.4") ]; then
+                echo "package python3-spidev can't be found, fetching from alternative location..."
+                DEBDIR=`mktemp -d /tmp/pimoroni.XXXXXX` && cd $DEBDIR
+                wget $RPIPOOL/main/s/spidev/$SPIDEV3 &> /dev/null
+                sudo dpkg -i $DEBDIR/$SPIDEV3 && FAILED_PKG=false
+            else
+                sudo $PIP3_BIN install spidev && FAILED_PKG=false
+            fi
+        fi
+        if [ "$pip2support" == "yes" ] && [ -f "$(which python2)" ]; then
+            if ! $PIP2_BIN list | grep "spidev" &> /dev/null; then
+                warning "Unable to install spidev for python 2!" && FAILED_PKG=true
+            else
+                SPIDEV2="install ok installed"
+            fi
+        fi
+        if [ "$pip3support" == "yes" ] && [ -f "$(which python3)" ]; then
+            if ! $PIP3_BIN list | grep "spidev" &> /dev/null; then
+                warning "Unable to install spidev for python 3!" && FAILED_PKG=true
+            else
+                SPIDEV3="install ok installed"
+            fi
+        fi
+        if [ "$SPIDEV2" == "install ok installed" ] || [ "$SPIDEV3" == "install ok installed" ]; then
+            if ! $FAILED_PKG; then
+                echo -e "spidev installed and up-to-date"
+            fi
+        fi
+    fi
+
+    if [ $i2creq == "yes" ]; then
+        newline
+        if ls /dev/i2c* &> /dev/null; then
+            inform "I2C already enabled"
+        else
+            echo "I2C must be enabled for $productname to work"
+            if command -v raspi-config > /dev/null && sudo raspi-config nonint get_i2c | grep -q "1"; then
+                sudo raspi-config nonint do_i2c 0
+                inform "I2C is now enabled"
+            else
+                curl -sS $GETPOOL/i2c | sudo bash -s - "-y" && ASK_TO_REBOOT=true
+            fi
+        fi
+        echo -e "\nChecking packages required by I2C interface..."
+        if [ "$pip2support" == "yes" ] && ! apt_pkg_install "python-smbus" &> /dev/null; then
+            FAILED_PKG=false
+            if [ -n $(python --version 2>&1 | grep -q "2.7") ]; then
+                echo "package python-smbus can't be found, fetching from alternative location..."
+                DEBDIR=`mktemp -d /tmp/pimoroni.XXXXXX` && cd $DEBDIR
+                wget $RPIPOOL/main/i/i2c-tools/$SMBUS2 &> /dev/null
+                sudo dpkg -i $DEBDIR/$SMBUS2 || FAILED_PKG=true
+            fi
+            if $FAILED_PKG; then
+                warning "Unable to install smbus for python 2!"
+            else
+                echo -e "Python 2 smbus installed and up-to-date"
+            fi
+        else
+            echo -e "Python 2 smbus installed and up-to-date"
+        fi
+        if [ "$pip3support" == "yes" ] && ! apt_pkg_install "python3-smbus" &> /dev/null; then
+            FAILED_PKG=false
+            if [ -n $(python3 --version 2>&1 | grep -q "3.4") ]; then
+                echo "package python3-smbus can't be found, fetching from alternative location..."
+                DEBDIR=`mktemp -d /tmp/pimoroni.XXXXXX` && cd $DEBDIR
+                wget $RPIPOOL/main/i/i2c-tools/$SMBUS3 &> /dev/null
+                sudo dpkg -i $DEBDIR/$SMBUS3 || FAILED_PKG=true
+            elif [ -n $(python3 --version 2>&1 | grep -q "3.5") ]; then
+                if apt_pkg_req "python3-smbus1" &> /dev/null; then
+                    echo "package python3-smbus can't be found, fetching from alternative location..."
+                    DEBDIR=`mktemp -d /tmp/pimoroni.XXXXXX` && cd $DEBDIR
+                    wget $GETPOOL/resources/$SMBUS35 &> /dev/null
+                    sudo dpkg -i $DEBDIR/$SMBUS35 || FAILED_PKG=true
+                fi
+            fi
+            if $FAILED_PKG; then
+                warning "Unable to install smbus for python 3!"
+            else
+                echo -e "Python 3 smbus installed and up-to-date"
+            fi
+        else
+            echo -e "Python 3 smbus installed and up-to-date"
+        fi
+    fi
+
+    if [ $i2sreq == "yes" ]; then
+        if [ -f /etc/asound.conf ]; then
+            sudo rm -f /etc/asound.conf.backup &> /dev/null
+            sudo mv /etc/asound.conf /etc/asound.conf.backup
+            inform "existing config backed up to /etc/asound.conf.backup"
+        fi
+        if [ -f $HOME/.asoundrc ]; then
+            sudo rm -f $HOME/.asoundrc.backup &> /dev/null
+            sudo mv $HOME/.asoundrc $HOME/.asoundrc.backup
+            inform "existing config backed up to ~/.asound.conf.backup"
+        fi
+    fi
+
+# minimum install routine
+
+    if [ $mininstall != "yes" ] && [ $gitrepoclone != "yes" ]; then
+        newline
+        echo "$productname comes with examples and documentation that you may wish to install."
+        echo "Performing a full install will ensure those resources are installed,"
+        echo "along with all required dependencies. It may however take a while!"
+        newline
+        if ! confirm "Do you wish to perform a full install?"; then
+            MIN_INSTALL=true
+        fi
+    else
+        MIN_INSTALL=true
+    fi
+
+    if [ $localdir != "na" ]; then
+        installdir="$USER_HOME/$topdir/$localdir"
+    else
+        installdir="$USER_HOME/$topdir"
+    fi
+
+    if ! $MIN_INSTALL || [ $gitrepoclone == "yes" ]; then
+        [ -d $installdir ] || mkdir -p $installdir
+    fi
+
+    if [ $debugmode != "no" ]; then
+        echo "INSTALLDIR is $installdir"
+    fi
+
+# apt repo install
+
+    echo -e "\nChecking for dependencies..."
+
+    if $REMOVE_PKG; then
+        for pkgrm in ${pkgremove[@]}; do
+            warning "Installed package conflicts with requirements"
+            sudo apt-get remove "$pkgrm"
+        done
+    fi
+
+    for pkgdep in ${coredeplist[@]}; do
+        if apt_pkg_req "$pkgdep"; then
+            apt_pkg_install "$pkgdep"
+        fi
+    done
+
+    for pkgdep in ${pythondep[@]}; do
+        if [ -f "$(which python2)" ] && [ $pip2support == "yes" ]; then
+            if apt_pkg_req "python-$pkgdep"; then
+                apt_pkg_install "python-$pkgdep"
+            fi
+        fi
+        if [ -f "$(which python3)" ] && [ $pip3support == "yes" ]; then
+            if apt_pkg_req "python3-$pkgdep"; then
+                apt_pkg_install "python3-$pkgdep"
+            fi
+        fi
+    done
+
+    if [ $pipoverride != "yes" ] && [ $debpackage != "na" ]; then
+        newline
+        if [ $pip2support != "yes" ] && [ $pip3support != "yes" ]; then
+            apt_deb_install "$debpackage"
+        fi
+        if [ -f "$(which python2)" ] && [ $pip2support == "yes" ]; then
+            apt_deb_install "python-$debpackage"
+            if ! apt_pkg_req "python-$debpackage" &> /dev/null; then
+                sudo $PIP2_BIN uninstall -y "$piplibname" &> /dev/null
+            fi
+        fi
+        if [ -f "$(which python3)" ] && [ $pip3support == "yes" ]; then
+            apt_deb_install "python3-$debpackage"
+            if ! apt_pkg_req "python3-$debpackage" &> /dev/null; then
+                sudo $PIP3_BIN uninstall -y "$piplibname" &> /dev/null
+            fi
+        fi
+        if apt_pkg_req "python-$debpackage" &> /dev/null || apt_pkg_req "python3-$debpackage" &> /dev/null; then
+            debpackage="na"
+        fi
+    else
+        debpackage="na"
+    fi
+
+# pypi repo install
+
+    if [ -f "$(which python2)" ] && [ $pip2support == "yes" ] && apt_pkg_req "python-$debpackage" &> /dev/null; then
+        if [ $piplibname != "na" ] && [ $debpackage == "na" ]; then
+            newline && echo "Installing $productname library for Python 2..." && newline
+            if ! sudo -H $PIP2_BIN install --upgrade "$piplibname"; then
+                warning "Python 2 library install failed!"
+                echo "If problems persist, visit forums.pimoroni.com for support"
+                exit 1
+            fi
+        fi
+    fi
+
+    if [ -f "$(which python3)" ] && [ $pip3support == "yes" ] && apt_pkg_req "python3-$debpackage" &> /dev/null; then
+        if [ $piplibname != "na" ] && [ $debpackage == "na" ]; then
+            newline && echo "Installing $productname library for Python 3..." && newline
+            if ! sudo -H $PIP3_BIN install --upgrade "$piplibname"; then
+                warning "Python 3 library install failed!"
+                echo "If problems persist, visit forums.pimoroni.com for support"
+                exit 1
+            fi
+        fi
+    fi
+
+# git repo install
+
+    if [ $gitrepoclone == "yes" ]; then
+        if ! command -v git > /dev/null; then
+            apt_pkg_install git
+        fi
+        if [ $gitclonedir == "source" ]; then
+            gitclonedir=$gitreponame
+        fi
+        if [ $repoclean == "yes" ]; then
+            rm -Rf $installdir/$gitclonedir
+        fi
+        if [ -d $installdir/$gitclonedir ]; then
+            newline && echo "Github repo already present. Updating..."
+            cd $installdir/$gitclonedir && git pull
+        else
+            newline && echo "Cloning Github repo locally..."
+            cd $installdir
+            if [ $debugmode != "no" ]; then
+                echo "git user name is $gitusername"
+                echo "git repo name is $gitreponame"
+            fi
+            if [ $gitrepobranch != "master" ]; then
+                git clone https://github.com/$gitusername/$gitreponame $gitclonedir -b $gitrepobranch
+            else
+                git clone --depth=1 https://github.com/$gitusername/$gitreponame $gitclonedir
+            fi
+        fi
+    fi
+
+    if [ $repoinstall == "yes" ]; then
+        newline && echo "Installing library..." && newline
+        cd $installdir/$gitreponame/$libdir
+        if [ -f "$(which python2)" ] && [ $pip2support == "yes" ]; then
+            sudo python2 ./setup.py install
+        fi
+        if [ -f "$(which python3)" ] && [ $pip3support == "yes" ]; then
+            sudo python3 ./setup.py install
+        fi
+        newline
+    fi
+
+# additional install
+
+    if ! $MIN_INSTALL; then
+        echo -e "\nChecking for additional software..."
+        for moredep in ${examplesdep[@]}; do
+            if [ -f "$(which python2)" ] && apt_pkg_req "python-$moredep"; then
+                if ! apt_pkg_install "python-$moredep"; then
+                    sudo -H $PIP2_BIN install "$moredep"
+                    if pip2_lib_req "$moredep"; then
+                        FAILED_PKG=true
+                    fi
+                fi
+            fi
+            if [ -f "$(which python3)" ] && apt_pkg_req "python3-$moredep"; then
+                if ! apt_pkg_install "python3-$moredep"; then
+                    sudo -H $PIP3_BIN install "$moredep"
+                    if pip3_lib_req "$moredep"; then
+                        FAILED_PKG=true
+                    fi
+                fi
+            fi
+        done
+        for pipdep in ${pipdeplist[@]}; do
+            if [ -f "$(which python2)" ] && pip2_lib_req "$pipdep"; then
+                sudo -H $PIP2_BIN install "$pipdep"
+            fi
+            if [ -f "$(which python3)" ] && pip3_lib_req "$pipdep"; then
+                sudo -H $PIP3_BIN install "$pipdep"
+            fi
+        done
+        for moredep in ${somemoredep[@]}; do
+            if apt_pkg_req "$moredep"; then
+                apt_pkg_install "$moredep"
+            fi
+        done
+        if [ -n "$DISPLAY" ]; then
+            for x11dep in ${xdisplaydep[@]}; do
+                if apt_pkg_req "$x11dep"; then
+                    apt_pkg_install "$x11dep"
+                fi
+            done
+        fi
+    fi
+
+# resources install
+
+    if ! $MIN_INSTALL && [ -n "$copydir" ]; then
+        if ! command -v git > /dev/null; then
+            apt_pkg_install git
+        fi
+        echo -e "\nDownloading examples and documentation..."
+        TMPDIR=`mktemp -d /tmp/pimoroni.XXXXXX`
+        cd $TMPDIR
+        if [ $copyhead != "yes" ]; then
+            GITTAG=$(git ls-remote -t https://github.com/$gitusername/$gitreponame v\?.?.? | tail -n 1 | rev | cut -c -6 | rev)
+        fi
+        if [ -n "$GITTAG" ]; then
+            git clone https://github.com/$gitusername/$gitreponame -b $GITTAG &> /dev/null
+        else
+            git clone --depth=1 https://github.com/$gitusername/$gitreponame &> /dev/null
+        fi
+        cd $installdir
+        for repodir in ${copydir[@]}; do
+            if [ -d $repodir ] && [ $repodir != "documentation" ]; then
+                newline
+                if [ -d $installdir/$repodir-backup ]; then
+                    rm -R $installdir/$repodir-old &> /dev/null
+                    mv $installdir/$repodir-backup $installdir/$repodir-old &> /dev/null
+                fi
+                mv $installdir/$repodir $installdir/$repodir-backup &> /dev/null
+                if [ $gitrepotop != "root" ]; then
+                    cp -R $TMPDIR/$gitreponame/$gitrepotop/$repodir $installdir/$repodir &> /dev/null
+                else
+                    cp -R $TMPDIR/$gitreponame/$repodir $installdir/$repodir &> /dev/null
+                fi
+                inform "The $repodir directory already exists on your system!"
+                echo -e "We've backed them up as $repodir-backup, just in case you've changed anything!\n"
+            else
+                rm -R $installdir/$repodir &> /dev/null
+                if [ $gitrepotop != "root" ]; then
+                    cp -R $TMPDIR/$gitreponame/$gitrepotop/$repodir $installdir/$repodir &> /dev/null
+                else
+                    cp -R $TMPDIR/$gitreponame/$repodir $installdir/$repodir &> /dev/null
+                fi
+            fi
+        done
+        echo "Resources for your $productname were copied to"
+        inform "$installdir"
+        rm -rf $TMPDIR
+    fi
+
+# script custom routines
+
+    if [ $customcmd == "no" ]; then
+        if [ -n "$pkgremove" ]; then
+            echo -e "\nFinalising Install...\n"
+            sysclean && newline
+        fi
+        echo -e "\nAll done. Enjoy your $productname!\n"
+    else # custom block starts here
+        echo -e "\nFinalising Install...\n"
+        # place all custom commands in this scope
+    fi
+
+    if $FAILED_PKG; then
+        warning "\nSome packages could not be installed, review the output for details!\n"
+    fi
+
+    if [ "$FORCE" != '-y' ]; then
+        if [ $promptreboot == "yes" ] || $ASK_TO_REBOOT; then
+            sysreboot && newline
+        fi
+    fi
+else
+    echo -e "\nAborting...\n"
+fi
+
+exit 0

--- a/documentation/REFERENCE.md
+++ b/documentation/REFERENCE.md
@@ -7,9 +7,15 @@ See `buttons.py` for an example of how to handle buttons. The library has 4 diff
 * `on_note` - triggers when a piano key is touched
 * `on_octave_up` - triggers when the Octave Up key is touched
 * `on_octave_down` - triggers when the Octave Down key is touched
-* `on_instrument` - triggeres when the Instrument key is touched
+* `on_instrument` - triggers when the Instrument key is touched
+
+Piano HAT uses two CAP1188 chips on the I2C bus:
+
+* `0x28` - keys C through G (indices 0-7)
+* `0x2b` - keys G# through C (indices 8-15)
 
 See `leds.py` for an example of how to take command of the Piano HAT LEDs. You can turn all of the LEDs on and off at will, useful for creating a visual metronome, prompting a user which key to press and more.
 
-* `set_led(x, True/False)` - lets you set a particular LED to on ( True ) or off ( False ).
-* `auto_leds(False)` - stops Piano HAT from automatically lighting the LEDs when a key is touched
+* `auto_leds(True)` - link LEDs to touch events (default behavior)
+* `auto_leds(False)` - unlink LEDs so you can control them manually
+* `set_led(x, True/False)` - set a particular LED on or off when manual control is enabled

--- a/driver_test.py
+++ b/driver_test.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2015-2026 Pimoroni Ltd
+# SPDX-FileCopyrightText: 2026 Piano HAT Contributors
+# SPDX-FileCopyrightText: 2026 Daniel Gentleman <code@danielgentleman.com>
+# Adafruit CircuitPython CAP1188: https://github.com/adafruit/Adafruit_CircuitPython_CAP1188
+#
+# Test driver for Piano HAT using Adafruit CAP1188 library
+# Maps both CAP1188 chips to logical piano keys
+
+import time
+import board
+from adafruit_cap1188.i2c import CAP1188_I2C
+
+# Button mapping for 16-key piano
+BUTTON_NAMES = {
+    0: "C",
+    1: "C#",
+    2: "D",
+    3: "D#",
+    4: "E",
+    5: "F",
+    6: "F#",
+    7: "G",
+    8: "G#",
+    9: "A",
+    10: "A#",
+    11: "B",
+    12: "C2",
+    13: "Octave Down",
+    14: "Octave Up",
+    15: "Instrument",
+}
+
+
+def main():
+    """Test both CAP1188 chips and print button presses."""
+    print("Piano HAT Button Test")
+    print("=" * 50)
+    print("Initializing CAP1188 controllers...")
+
+    try:
+        i2c = board.I2C()
+    except RuntimeError as e:
+        print(f"ERROR: Could not initialize I2C: {e}")
+        print("Make sure I2C is enabled and Piano HAT is connected")
+        return
+
+    # Initialize both CAP1188 chips
+    try:
+        cap_ctog = CAP1188_I2C(i2c, address=0x28)  # C-G
+        print("✓ CAP1188 at 0x28 (C-G) initialized")
+    except Exception as e:
+        print(f"✗ Could not initialize CAP1188 at 0x28: {e}")
+        return
+
+    try:
+        cap_atoc = CAP1188_I2C(i2c, address=0x2b)  # G#-C
+        print("✓ CAP1188 at 0x2b (G#-C) initialized")
+    except Exception as e:
+        print(f"✗ Could not initialize CAP1188 at 0x2b: {e}")
+        return
+
+    print("\nListening for button presses...")
+    print("(Press Ctrl+C to exit)\n")
+
+    # Track previous state for debouncing
+    prev_state = [[False] * 8 for _ in range(2)]
+
+    try:
+        while True:
+            # Read from both chips
+            current_time = time.time()
+
+            # Check chip 1 (0x28) - keys 0-7 (C-G)
+            for i in range(8):
+                # CAP1188 uses 1-based pad indexing
+                is_pressed = cap_ctog[i + 1].value
+
+                if is_pressed != prev_state[0][i]:
+                    button_name = BUTTON_NAMES[i]
+                    state = "PRESSED" if is_pressed else "RELEASED"
+                    print(f"[{current_time:.2f}] Button {i:2d} ({button_name:15s}) {state}")
+                    prev_state[0][i] = is_pressed
+
+            # Check chip 2 (0x2b) - keys 8-15 (G#-C, Octave Down, Octave Up, Instrument)
+            for i in range(8):
+                # CAP1188 uses 1-based pad indexing
+                is_pressed = cap_atoc[i + 1].value
+                button_idx = i + 8
+
+                if is_pressed != prev_state[1][i]:
+                    button_name = BUTTON_NAMES[button_idx]
+                    state = "PRESSED" if is_pressed else "RELEASED"
+                    print(f"[{current_time:.2f}] Button {button_idx:2d} ({button_name:15s}) {state}")
+                    prev_state[1][i] = is_pressed
+
+            # Debounce delay - check every 20ms
+            time.sleep(0.02)
+
+    except KeyboardInterrupt:
+        print("\n\nTest ended by user")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/8bit-synth.py
+++ b/examples/8bit-synth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import math
 import signal
@@ -8,12 +8,12 @@ from sys import exit
 try:
     import numpy
 except ImportError:
-    exit("This script requires the numpy module\nInstall with: sudo pip install numpy")
+    exit("This script requires the numpy module\nInstall with: pip3 install numpy")
 
 try:
     import pygame
 except ImportError:
-    exit("This script requires the pygame module\nInstall with: sudo pip install pygame")
+    exit("This script requires the pygame module\nInstall with: pip3 install pygame")
 
 import pianohat
 

--- a/examples/buttons.py
+++ b/examples/buttons.py
@@ -16,7 +16,7 @@ Press CTRL+C to exit.
 pianohat.auto_leds(True)
 
 def handle_touch(ch, evt):
-    print(ch, evt)
+    print(ch, evt, flush=True)
 
 pianohat.on_note(handle_touch)
 pianohat.on_octave_up(handle_touch)

--- a/examples/buttons.py
+++ b/examples/buttons.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import signal
 

--- a/examples/learn-to-play.py
+++ b/examples/learn-to-play.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import signal
@@ -8,7 +8,7 @@ from sys import exit
 try:
     import pygame
 except ImportError:
-    exit("This script requires the pygame module\nInstall with: sudo pip install pygame")
+    exit("This script requires the pygame module\nInstall with: pip3 install pygame")
 
 import pianohat
 

--- a/examples/leds.py
+++ b/examples/leds.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 

--- a/examples/midi-piano.py
+++ b/examples/midi-piano.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import glob
 import os
@@ -11,12 +11,12 @@ try:
     import midi
     import midi.sequencer
 except ImportError:
-    exit("This script requires the midi module\nInstall with: sudo pip install midi")
+    exit("This script requires the midi module\nInstall with: pip3 install python-midi")
 
 try:
     import pygame
 except ImportError:
-    exit("This script requires the pygame module\nInstall with: sudo pip install pygame")
+    exit("This script requires the pygame module\nInstall with: pip3 install pygame")
 
 import pianohat
 

--- a/examples/simple-piano.py
+++ b/examples/simple-piano.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import glob
 import os
@@ -9,7 +9,7 @@ from sys import exit
 try:
     import pygame
 except ImportError:
-    exit("This script requires the pygame module\nInstall with: sudo pip install pygame")
+    exit("This script requires the pygame module\nInstall with: pip3 install pygame")
 
 import pianohat
 
@@ -57,7 +57,7 @@ def load_samples(patch):
     for filetype in FILETYPES:
         files.extend(glob.glob(os.path.join(patch, filetype)))
     files.sort(key=natural_sort_key)
-    octaves = len(files) / 12
+    octaves = len(files) // 12
     samples = [pygame.mixer.Sound(sample) for sample in files]
     octave = int(octaves / 2)
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,286 @@
+#!/bin/bash
+
+# Piano HAT Modern Installer
+# For Raspberry Pi OS (64-bit and 32-bit)
+# Python 3 only
+
+set -e
+
+SCRIPT_VERSION="2.0.0"
+PRODUCT_NAME="Piano HAT"
+LIB_NAME="pianohat"
+PYTHON_MIN_VERSION="3.7"
+IN_VENV=0
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if running in a virtual environment
+check_venv() {
+    if [ -n "$VIRTUAL_ENV" ]; then
+        IN_VENV=1
+        info "Running in virtual environment: $VIRTUAL_ENV"
+    fi
+}
+
+# Check if running on Raspberry Pi
+check_platform() {
+    if [ ! -f /proc/device-tree/model ]; then
+        warn "Not running on Raspberry Pi. Some features may not work."
+        return 0
+    fi
+    
+    MODEL=$(cat /proc/device-tree/model 2>/dev/null | tr -d '\0')
+    info "Detected: $MODEL"
+}
+
+# Check Python version
+check_python() {
+    if ! command -v python3 &> /dev/null; then
+        error "Python 3 is not installed!"
+        echo "Install with: sudo apt-get install python3"
+        exit 1
+    fi
+    
+    PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
+    info "Python version: $PYTHON_VERSION"
+    
+    # Simple version check (requires 3.7+)
+    MAJOR=$(echo $PYTHON_VERSION | cut -d. -f1)
+    MINOR=$(echo $PYTHON_VERSION | cut -d. -f2)
+    
+    if [ "$MAJOR" -lt 3 ] || ([ "$MAJOR" -eq 3 ] && [ "$MINOR" -lt 7 ]); then
+        error "Python $PYTHON_MIN_VERSION or higher is required"
+        exit 1
+    fi
+}
+
+# Check if I2C is enabled
+check_i2c() {
+    if ! grep -q "^dtparam=i2c_arm=on" /boot/config.txt && \
+       ! grep -q "^dtparam=i2c_arm=on" /boot/firmware/config.txt 2>/dev/null; then
+        warn "I2C may not be enabled"
+        echo ""
+        echo "Piano HAT requires I2C to be enabled."
+        echo "You can enable it using:"
+        echo "  sudo raspi-config"
+        echo "  Then: Interface Options -> I2C -> Enable"
+        echo ""
+        read -p "Continue anyway? [y/N] " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+    else
+        info "I2C appears to be enabled"
+    fi
+}
+
+# Install system dependencies
+install_dependencies() {
+    if [ "$IN_VENV" -eq 1 ]; then
+        info "Running in venv, skipping system package installation"
+        info "Make sure system has: i2c-tools python3-smbus"
+        return 0
+    fi
+    
+    if ! command -v apt-get &> /dev/null; then
+        warn "apt-get not found, skipping system dependencies"
+        return 0
+    fi
+    
+    info "Installing system dependencies..."
+    
+    # Update package list
+    sudo apt-get update -qq || {
+        warn "Failed to update package list"
+    }
+    
+    # Install required system packages
+    sudo apt-get install -y \
+        python3-pip \
+        python3-dev \
+        python3-setuptools \
+        i2c-tools \
+        python3-smbus || {
+            error "Failed to install system dependencies"
+            exit 1
+        }
+    
+    info "System dependencies installed"
+}
+
+# Install Python library
+install_library() {
+    info "Installing $PRODUCT_NAME library..."
+    
+    # Handle PEP 668 externally-managed environments
+    if [ "$IN_VENV" -eq 0 ]; then
+        # Not in a venv, check if system is externally managed
+        if python3 -m pip install --dry-run pip 2>&1 | grep -q "externally-managed-environment"; then
+            error "This system uses externally-managed Python packages (PEP 668)"
+            echo ""
+            echo "You have three options:"
+            echo "  1. Create a virtual environment (RECOMMENDED):"
+            echo "     python3 -m venv --system-site-packages ~/pianohat-env"
+            echo "     source ~/pianohat-env/bin/activate"
+            echo "     ./install.sh"
+            echo ""
+            echo "  2. Use --break-system-packages (NOT RECOMMENDED):"
+            echo "     Edit this script and add --break-system-packages to pip commands"
+            echo ""
+            echo "  3. Use system packages only (LIMITED):"
+            echo "     May not have latest version"
+            echo ""
+            exit 1
+        fi
+    fi
+    
+    # Check if we're in the repo
+    if [ -f "library/pyproject.toml" ]; then
+        info "Installing from local source..."
+        cd library
+        python3 -m pip install --upgrade pip setuptools wheel
+        python3 -m pip install -e .
+        cd ..
+    else
+        info "Installing from PyPI..."
+        python3 -m pip install --upgrade "$LIB_NAME"
+    fi
+    
+    info "$PRODUCT_NAME library installed"
+}
+
+# Install example dependencies (optional)
+install_examples() {
+    if [ "$INSTALL_EXAMPLES" == "yes" ]; then
+        info "Installing example dependencies..."
+        python3 -m pip install pygame numpy || {
+            warn "Failed to install some example dependencies"
+        }
+    fi
+}
+
+# Copy examples
+copy_examples() {
+    if [ "$INSTALL_EXAMPLES" == "yes" ]; then
+        INSTALL_DIR="$HOME/pianohat-examples"
+        
+        if [ -d "examples" ]; then
+            info "Copying examples to $INSTALL_DIR..."
+            mkdir -p "$INSTALL_DIR"
+            cp -r examples/* "$INSTALL_DIR/"
+            info "Examples copied to $INSTALL_DIR"
+        fi
+    fi
+}
+
+# Test I2C devices
+test_i2c() {
+    info "Checking for I2C devices..."
+    
+    if command -v i2cdetect &> /dev/null; then
+        # Try both I2C buses
+        for bus in 0 1; do
+            if sudo i2cdetect -y $bus 2>/dev/null | grep -q "28\|2b"; then
+                info "Piano HAT detected on I2C bus $bus"
+                return 0
+            fi
+        done
+        warn "Piano HAT not detected on I2C bus. Make sure it's properly connected."
+    else
+        warn "i2cdetect not available, skipping hardware check"
+    fi
+}
+
+# Main installation
+main() {
+    echo ""
+    echo "========================================="
+    echo "  $PRODUCT_NAME Installer v$SCRIPT_VERSION"
+    echo "========================================="
+    echo ""
+    
+    # Parse arguments
+    INSTALL_EXAMPLES="no"
+    SKIP_DEPS="no"
+    
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --examples)
+                INSTALL_EXAMPLES="yes"
+                shift
+                ;;
+            --skip-deps)
+                SKIP_DEPS="yes"
+                shift
+                ;;
+            -y|--yes)
+                # Auto-confirm
+                shift
+                ;;
+            *)
+                echo "Unknown option: $1"
+                echo "Usage: $0 [--examples] [--skip-deps] [-y]"
+                exit 1
+                ;;
+        esac
+    done
+    
+    # Prompt for examples if not specified
+    if [ "$INSTALL_EXAMPLES" == "no" ]; then
+        read -p "Install examples and their dependencies? [Y/n] " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+            INSTALL_EXAMPLES="yes"
+        fi
+    fi
+    
+    # Run checks
+    check_venv
+    check_platform
+    check_python
+    check_i2c
+    
+    # Install
+    if [ "$SKIP_DEPS" == "no" ]; then
+        install_dependencies
+    fi
+    
+    install_library
+    install_examples
+    copy_examples
+    test_i2c
+    
+    echo ""
+    info "Installation complete!"
+    echo ""
+    
+    if [ "$INSTALL_EXAMPLES" == "yes" ]; then
+        info "Examples are in: $HOME/pianohat-examples"
+        echo ""
+    fi
+    
+    info "To use Piano HAT in Python:"
+    echo "  import pianohat"
+    echo ""
+    info "Documentation: https://github.com/pimoroni/piano-hat"
+    echo ""
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,46 @@ check_venv() {
     if [ -n "$VIRTUAL_ENV" ]; then
         IN_VENV=1
         info "Running in virtual environment: $VIRTUAL_ENV"
+        
+        # Check if venv has --system-site-packages enabled
+        if [ ! -f "$VIRTUAL_ENV/pyvenv.cfg" ] || ! grep -q "include-system-site-packages = true" "$VIRTUAL_ENV/pyvenv.cfg" 2>/dev/null; then
+            warn "Virtual environment may not have --system-site-packages enabled"
+            echo ""
+            echo "Piano HAT requires access to system packages like python3-smbus."
+            echo "If you encounter 'No module named smbus' errors, recreate your venv with:"
+            echo "  deactivate"
+            echo "  rm -rf venv"
+            echo "  python3 -m venv --system-site-packages venv"
+            echo "  source venv/bin/activate"
+            echo ""
+            read -p "Continue anyway? [Y/n] " -n 1 -r
+            echo
+            if [[ $REPLY =~ ^[Nn]$ ]]; then
+                echo "Installation cancelled."
+                exit 0
+            fi
+        fi
+    else
+        # Check if system is externally managed (PEP 668)
+        if [ -f /usr/lib/python*/EXTERNALLY-MANAGED ] 2>/dev/null || \
+           python3 -m pip install --dry-run pip 2>&1 | grep -q "externally-managed-environment"; then
+            warn "Modern Raspberry Pi OS uses externally-managed Python packages (PEP 668)"
+            echo ""
+            echo "It is STRONGLY RECOMMENDED to use a virtual environment."
+            echo ""
+            echo "Quick setup:"
+            echo "  python3 -m venv --system-site-packages venv"
+            echo "  source venv/bin/activate"
+            echo "  ./install.sh"
+            echo ""
+            read -p "Continue anyway WITHOUT virtual environment? [y/N] " -n 1 -r
+            echo
+            if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                echo "Installation cancelled. Please create a virtual environment first."
+                exit 0
+            fi
+            warn "Proceeding without virtual environment - installation may fail"
+        fi
     fi
 }
 
@@ -94,8 +134,32 @@ check_i2c() {
 # Install system dependencies
 install_dependencies() {
     if [ "$IN_VENV" -eq 1 ]; then
-        info "Running in venv, skipping system package installation"
-        info "Make sure system has: i2c-tools python3-smbus"
+        info "Running in venv, but some system packages are still required"
+        
+        # Even in a venv, we need system packages for I2C and building C extensions
+        if ! command -v apt-get &> /dev/null; then
+            error "apt-get not found, cannot install required system dependencies"
+            echo "Please manually install: python3-dev python3-smbus i2c-tools"
+            exit 1
+        fi
+        
+        info "Installing required system packages..."
+        sudo apt-get update -qq || {
+            warn "Failed to update package list"
+        }
+        
+        # These packages MUST be installed at system level
+        sudo apt-get install -y python3-dev python3-smbus i2c-tools || {
+            error "Failed to install required system packages (python3-dev python3-smbus i2c-tools)"
+            echo ""
+            echo "These packages are required for Piano HAT to work."
+            echo "Please install them manually with:"
+            echo "  sudo apt-get install python3-dev python3-smbus i2c-tools"
+            echo ""
+            exit 1
+        }
+        
+        info "System packages installed successfully"
         return 0
     fi
     
@@ -116,8 +180,7 @@ install_dependencies() {
         python3-pip \
         python3-dev \
         python3-setuptools \
-        i2c-tools \
-        python3-smbus || {
+        i2c-tools || {
             error "Failed to install system dependencies"
             exit 1
         }
@@ -215,6 +278,12 @@ main() {
     echo "  $PRODUCT_NAME Installer v$SCRIPT_VERSION"
     echo "========================================="
     echo ""
+    echo "Recommended setup (first time):"
+    echo "  1. sudo apt-get install python3-dev python3-smbus i2c-tools"
+    echo "  2. python3 -m venv --system-site-packages venv"
+    echo "  3. source venv/bin/activate"
+    echo "  4. ./install.sh"
+    echo ""
     
     # Parse arguments
     INSTALL_EXAMPLES="no"
@@ -234,9 +303,31 @@ main() {
                 # Auto-confirm
                 shift
                 ;;
+            -h|--help)
+                echo "Usage: $0 [OPTIONS]"
+                echo ""
+                echo "Options:"
+                echo "  --examples        Install example scripts and dependencies"
+                echo "  --skip-deps       Skip system dependency installation"
+                echo "  -y, --yes         Auto-confirm all prompts"
+                echo "  -h, --help        Show this help message"
+                echo ""
+                echo "Recommended installation:"
+                echo "  1. Install system packages:"
+                echo "     sudo apt-get install python3-dev python3-smbus i2c-tools"
+                echo ""
+                echo "  2. Create virtual environment:"
+                echo "     python3 -m venv --system-site-packages venv"
+                echo "     source venv/bin/activate"
+                echo ""
+                echo "  3. Run installer:"
+                echo "     ./install.sh --examples"
+                echo ""
+                exit 0
+                ;;
             *)
                 echo "Unknown option: $1"
-                echo "Usage: $0 [--examples] [--skip-deps] [-y]"
+                echo "Usage: $0 [--examples] [--skip-deps] [-y] [-h|--help]"
                 exit 1
                 ;;
         esac
@@ -266,6 +357,24 @@ main() {
     install_examples
     copy_examples
     test_i2c
+    
+    # Verify installation
+    info "Verifying installation..."
+    if python3 -c "import pianohat" 2>/dev/null; then
+        info "Installation verified successfully!"
+    else
+        error "Installation verification failed!"
+        echo ""
+        echo "The pianohat module could not be imported."
+        echo "This may indicate missing dependencies or system packages."
+        echo ""
+        echo "Please check the error messages above and ensure:"
+        echo "  - python3-smbus is installed: sudo apt-get install python3-smbus"
+        echo "  - python3-dev is installed: sudo apt-get install python3-dev"
+        echo "  - i2c-tools is installed: sudo apt-get install i2c-tools"
+        echo ""
+        exit 1
+    fi
     
     echo ""
     info "Installation complete!"

--- a/library/pianohat.py
+++ b/library/pianohat.py
@@ -1,41 +1,36 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2015-2026 Pimoroni Ltd
+# Adafruit CircuitPython CAP1188: https://github.com/adafruit/Adafruit_CircuitPython_CAP1188
+# SPDX-FileCopyrightText: 2026 Daniel Gentleman <code@danielgentleman.com>
 """Piano HAT library for Raspberry Pi.
 
 This library provides an interface to the Piano HAT, a 13-key capacitive
 touch piano with additional control buttons.
 
-Requires the cap1xxx library for I2C communication with the capacitive
-touch controllers.
+Uses the Adafruit CAP1188 library for I2C communication with the capacitive
+touch controllers. No GPIO interrupts required - uses polling instead.
 """
 
-import signal
-from sys import exit
+import time
+import threading
 from typing import Callable, List, Optional, Union
 
 try:
-    import cap1xxx
+    import board
+    from adafruit_cap1188.i2c import CAP1188_I2C
 except ImportError as exc:
     raise ImportError(
-        "This library requires the cap1xxx module\n"
-        "Install with: pip3 install cap1xxx"
+        "This library requires the adafruit-circuitpython-cap1188 module\n"
+        "Install with: pip3 install adafruit-circuitpython-cap1188"
     ) from exc
 
-__version__ = '0.2.0'
+__version__ = '0.3.1'
 
 # Event handler type
 EventHandler = Optional[Callable[[int, bool], None]]
 
-_on_note: EventHandler = None
-_on_octave_up: EventHandler = None
-_on_octave_down: EventHandler = None
-_on_instrument: EventHandler = None
-
-_is_setup: bool = False
-_pressed: List[bool] = [False for x in range(16)]
-
-PRESSED  = True
-RELEASED = False
-
+# Piano key constants
 C = 0
 CSHARP = 1
 D = 2
@@ -50,189 +45,258 @@ ASHARP = 10
 B = 11
 C2 = 12
 
+# Control buttons
 OCTAVE_DOWN = 13
-OCTAVE_UP   = 14
-INSTRUMENT  = 15
+OCTAVE_UP = 14
+INSTRUMENT = 15
+
+# Event states
+PRESSED = True
+RELEASED = False
+
+# CAP1188 LED register map (from cap1xxx)
+R_LED_LINKING = 0x72
+R_LED_OUTPUT_CON = 0x74
+R_LED_BEHAVIOUR_1 = 0x81  # LEDs 1-4
+R_LED_BEHAVIOUR_2 = 0x82  # LEDs 5-8
+R_LED_DIRECT_RAMP = 0x94
+
+LED_BEHAVIOUR_DIRECT = 0b00
 
 
-def _setup_cap(cap: 'cap1xxx.Cap1188') -> None:
-    """Configure a CAP1188 touch controller for Piano HAT use."""
-    for x in range(8):
-        cap._write_byte(0x30 + x, 0b00000110)
-
-    cap._write_byte(cap1xxx.R_LED_BEHAVIOUR_1, 0b00000000)
-    cap._write_byte(cap1xxx.R_LED_BEHAVIOUR_2, 0b00000000)
-    cap._write_byte(cap1xxx.R_LED_LINKING,     0b11111111)
-
-    cap._write_byte(cap1xxx.R_SAMPLING_CONFIG, 0b00000000)
-    cap._write_byte(cap1xxx.R_SENSITIVITY,     0b01100000)
-    cap._write_byte(cap1xxx.R_GENERAL_CONFIG, 0b00111000)
-    cap._write_byte(cap1xxx.R_CONFIGURATION2, 0b01100000)
-    cap.set_touch_delta(10)
-    cap.set_led_direct_ramp_rate(0, 0)
-
-
-def _handle_event(cap_index: int, event, state: bool) -> None:
-    """Handle touch events from the capacitive touch controllers."""
-    global _pressed
-    offset = 0
-    if cap_index == 1:
-        offset = 8
- 
-    channel = offset + event.channel
-
-    _pressed[channel] = (state == PRESSED)
+class PianoHAT:
+    """Piano HAT controller using Adafruit CAP1188 library.
     
-    if channel == OCTAVE_DOWN and callable(_on_octave_down):
-        _on_octave_down(channel, state)
-    if channel == OCTAVE_UP and callable(_on_octave_up):
-        _on_octave_up(channel, state)
-    if channel == INSTRUMENT and callable(_on_instrument):
-        _on_instrument(channel, state)
-    if channel <= 12 and callable(_on_note):
-        _on_note(channel, state)
-
-
-def auto_leds(enable: bool = True) -> None:
-    """Enable or disable automatic LEDs
-
-    :param enable: enable or disable: True/False
-
-    on automatic, the corresponding LED will light when 
-    a key is touched and turn off when it is released.
-
+    Provides polling-based button detection (no GPIO interrupts required).
+    Works on modern Raspberry Pi OS (Bullseye, Bookworm, etc.)
     """
 
-    setup()
+    def __init__(self):
+        """Initialize Piano HAT with both CAP1188 controllers."""
+        try:
+            i2c = board.I2C()
+        except RuntimeError as exc:
+            raise RuntimeError(
+                "Could not initialize I2C. Make sure I2C is enabled and accessible."
+            ) from exc
 
-    _piano_ctog._write_byte(cap1xxx.R_LED_LINKING, 0b11111111 * enable)
-    _piano_atoc._write_byte(cap1xxx.R_LED_LINKING, 0b11111111 * enable)
+        # Initialize both CAP1188 chips
+        try:
+            self._cap_ctog = CAP1188_I2C(i2c, address=0x28)  # C-G
+            self._cap_atoc = CAP1188_I2C(i2c, address=0x2b)  # G#-C
+        except RuntimeError as exc:
+            raise RuntimeError(
+                "Could not find Piano HAT on I2C bus. "
+                "Verify it's connected and I2C is enabled."
+            ) from exc
+
+        # State tracking
+        self._pressed = [False] * 16
+        self._prev_pressed = [False] * 16
+
+        # LED control
+        self._auto_leds = True
+        self._configure_leds()
+
+        # Event handlers
+        self._on_note: EventHandler = None
+        self._on_octave_up: EventHandler = None
+        self._on_octave_down: EventHandler = None
+        self._on_instrument: EventHandler = None
+
+        # Polling configuration
+        self._polling_enabled = False
+        self._polling_thread: Optional[threading.Thread] = None
+        self._polling_interval = 0.02  # 20ms poll interval
+        self._stop_polling = False
+
+    def _configure_leds(self) -> None:
+        """Configure default LED behavior and linking."""
+        self._set_led_behaviour(self._cap_ctog, LED_BEHAVIOUR_DIRECT)
+        self._set_led_behaviour(self._cap_atoc, LED_BEHAVIOUR_DIRECT)
+        self._set_led_linking(self._cap_ctog, True)
+        self._set_led_linking(self._cap_atoc, True)
+
+    def _set_led_behaviour(self, cap: CAP1188_I2C, behaviour: int) -> None:
+        """Set LED behaviour for all LEDs on a chip."""
+        value = (behaviour & 0b11)
+        packed = (value | (value << 2) | (value << 4) | (value << 6))
+        cap._write_register(R_LED_BEHAVIOUR_1, packed)
+        cap._write_register(R_LED_BEHAVIOUR_2, packed)
+
+    def _set_led_linking(self, cap: CAP1188_I2C, enable: bool) -> None:
+        """Enable or disable LED linking for all LEDs on a chip."""
+        cap._write_register(R_LED_LINKING, 0xFF if enable else 0x00)
+
+    def _set_led_state(self, cap: CAP1188_I2C, led_index: int, state: bool) -> None:
+        """Set a single LED state on a chip."""
+        current = cap._read_register(R_LED_OUTPUT_CON)
+        if state:
+            current |= (1 << led_index)
+        else:
+            current &= ~(1 << led_index)
+        cap._write_register(R_LED_OUTPUT_CON, current)
+
+    def _set_led_ramp_rate(self, cap: CAP1188_I2C, rise: int, fall: int) -> None:
+        """Set LED rise/fall ramp rate for a chip."""
+        rise_rate = min(7, max(0, int(round(rise / 250.0))))
+        fall_rate = min(7, max(0, int(round(fall / 250.0))))
+        cap._write_register(R_LED_DIRECT_RAMP, (rise_rate << 4) | fall_rate)
+
+    def _cap_for_led(self, index: int) -> CAP1188_I2C:
+        return self._cap_ctog if index < 8 else self._cap_atoc
+
+    def _led_index_for_cap(self, index: int) -> int:
+        return index if index < 8 else index - 8
+
+    def setup(self) -> bool:
+        """Initialize polling thread. Called automatically on first handler registration."""
+        if not self._polling_enabled:
+            self._polling_enabled = True
+            self._stop_polling = False
+            self._polling_thread = threading.Thread(
+                target=self._poll_loop, daemon=True
+            )
+            self._polling_thread.start()
+        return True
+
+    def _poll_loop(self) -> None:
+        """Background polling thread - checks button state and fires events."""
+        while not self._stop_polling:
+            self._check_buttons()
+            time.sleep(self._polling_interval)
+
+    def _check_buttons(self) -> None:
+        """Check all 16 buttons and fire events on state changes."""
+        # Check first CAP1188 (0x28) - buttons 0-7
+        for i in range(8):
+            pressed = self._cap_ctog[i + 1].value  # CAP1188 uses 1-based indexing
+            if pressed != self._prev_pressed[i]:
+                self._pressed[i] = pressed
+                self._prev_pressed[i] = pressed
+                self._handle_event(i, pressed)
+
+        # Check second CAP1188 (0x2b) - buttons 8-15
+        for i in range(8):
+            pressed = self._cap_atoc[i + 1].value
+            button_idx = i + 8
+            if pressed != self._prev_pressed[button_idx]:
+                self._pressed[button_idx] = pressed
+                self._prev_pressed[button_idx] = pressed
+                self._handle_event(button_idx, pressed)
+
+    def _handle_event(self, channel: int, pressed: bool) -> None:
+        """Route button events to appropriate handlers."""
+        if channel <= 12 and callable(self._on_note):
+            self._on_note(channel, pressed)
+        elif channel == OCTAVE_UP and callable(self._on_octave_up):
+            self._on_octave_up(channel, pressed)
+        elif channel == OCTAVE_DOWN and callable(self._on_octave_down):
+            self._on_octave_down(channel, pressed)
+        elif channel == INSTRUMENT and callable(self._on_instrument):
+            self._on_instrument(channel, pressed)
 
 
-def set_led(index: int, state: bool) -> None:
-    """Turn an  LED on or off
-
-    :param index: index of the LED to toggle: from 0 to 15
-    :param state: state to set the LED: either False or True
-
-    """
-
-    setup()
-
-    if index >= 8:
-        _piano_atoc.set_led_state(index - 8, state)
-    else:
-        _piano_ctog.set_led_state(index, state)
-
-
-def set_led_ramp_rate(rise: int, fall: int) -> None:
-    """Set the time it takes an LED to turn on or off
-
-    :param rise: time it takes LED to light in milliseconds
-    :param fall: time it takes LED to turn off in milliseconds
-
-    """
-
-    setup()
-
-    _piano_ctog.set_led_direct_ramp_rate(rise, fall)
-    _piano_atoc.set_led_direct_ramp_rate(rise, fall)
-
-
-def get_state(index: int = -1) -> Union[bool, List[bool]]:
-    """Get the state of a single key
-
-    :param index: index of key to return, from 0 to 15
-
-    """
-
-    setup()
-
-    if index > 0 and index < 16:
-        return _pressed[index]
-    else:
-        return _pressed
-
-
-def on_note(handler: EventHandler) -> None:
-    """Register handler for press/release of note key
-
-    :param handler: handler function to register
-
-    The handler function should expect two arguments.
-
-    The first is the button index that got the event,
-    and the second is True for pressed and False for released.
-
-    """
-
-    global _on_note
-    setup()
-    _on_note = handler
-
-
-def on_octave_up(handler: EventHandler) -> None:
-    """Register handler for press/release of octave_up key
-
-    :param handler: handler function to register
-
-    See on_note for details.
-
-    """
-
-    global _on_octave_up
-    setup()
-    _on_octave_up = handler
-
-
-def on_octave_down(handler: EventHandler) -> None:
-    """Register handler for press/release of octave_down key
-
-    :param handler: handler function to register
-
-    See on_note for details.
-
-    """
-
-    global _on_octave_down
-    setup()
-    _on_octave_down = handler
-
-
-def on_instrument(handler: EventHandler) -> None:
-    """Register handler for press/release of instrument key
-
-    :param handler: handler function to register
-
-    See on_note for details.
-
-    """
-
-    global _on_instrument
-    setup()
-    _on_instrument = handler
+# Global singleton instance
+_piano: Optional[PianoHAT] = None
 
 
 def setup() -> bool:
-    global _is_setup, _piano_ctog, _piano_atoc
+    """Initialize Piano HAT.
 
-    if _is_setup:
-        return True
-
-    # Keys C, C#, D, D#, E, F, F# and G
-    _piano_ctog = cap1xxx.Cap1188(i2c_addr=0x28, alert_pin=4)
-    _setup_cap(_piano_ctog)
-
-    # Keys G#, A, A#, B, C, Instrument, Octave -, Octave +
-    _piano_atoc = cap1xxx.Cap1188(i2c_addr=0x2b, alert_pin=27)
-    _setup_cap(_piano_atoc)
-
-    for x in range(0, 8):
-        _piano_ctog.on(x, event='press', handler=lambda evt: _handle_event(0, evt, PRESSED))
-        _piano_ctog.on(x, event='release', handler=lambda evt: _handle_event(0, evt, RELEASED))
-        _piano_atoc.on(x, event='press', handler=lambda evt: _handle_event(1, evt, PRESSED))
-        _piano_atoc.on(x, event='release', handler=lambda evt: _handle_event(1, evt, RELEASED))
-
-    _is_setup = True
+    Called automatically by event registration functions.
+    Safe to call multiple times.
+    """
+    global _piano
+    if _piano is None:
+        _piano = PianoHAT()
+        _piano.setup()
     return True
 
+
+def on_note(handler: EventHandler) -> None:
+    """Register handler for note key press/release.
+
+    :param handler: Function(channel, pressed) where:
+        - channel: 0-12 (C to C)
+        - pressed: True for press, False for release
+    """
+    setup()
+    _piano._on_note = handler
+
+
+def on_octave_up(handler: EventHandler) -> None:
+    """Register handler for octave up button.
+
+    :param handler: Function(channel, pressed)
+    """
+    setup()
+    _piano._on_octave_up = handler
+
+
+def on_octave_down(handler: EventHandler) -> None:
+    """Register handler for octave down button.
+
+    :param handler: Function(channel, pressed)
+    """
+    setup()
+    _piano._on_octave_down = handler
+
+
+def on_instrument(handler: EventHandler) -> None:
+    """Register handler for instrument button.
+
+    :param handler: Function(channel, pressed)
+    """
+    setup()
+    _piano._on_instrument = handler
+
+
+def get_state(index: int = -1) -> Union[bool, List[bool]]:
+    """Get the state of buttons.
+
+    :param index: Button index (0-15) or -1 for all buttons
+    :return: Single boolean if index specified, list of booleans otherwise
+    """
+    setup()
+    if 0 <= index < 16:
+        return _piano._pressed[index]
+    return _piano._pressed.copy()
+
+
+def auto_leds(enable: bool = True) -> None:
+    """Enable or disable automatic LED control.
+
+    :param enable: True to link LEDs to touches, False for manual control
+    """
+    setup()
+    _piano._auto_leds = enable
+    _piano._set_led_behaviour(_piano._cap_ctog, LED_BEHAVIOUR_DIRECT)
+    _piano._set_led_behaviour(_piano._cap_atoc, LED_BEHAVIOUR_DIRECT)
+    _piano._set_led_linking(_piano._cap_ctog, enable)
+    _piano._set_led_linking(_piano._cap_atoc, enable)
+
+
+def set_led(index: int, state: bool) -> None:
+    """Control an individual LED.
+
+    :param index: LED index (0-15)
+    :param state: True to turn on, False to turn off
+    """
+    if not 0 <= index < 16:
+        return
+    setup()
+    cap = _piano._cap_for_led(index)
+    led_index = _piano._led_index_for_cap(index)
+    _piano._set_led_state(cap, led_index, state)
+
+
+def set_led_ramp_rate(rise: int, fall: int) -> None:
+    """Set LED fade rate.
+
+    :param rise: Rise time in milliseconds
+    :param fall: Fall time in milliseconds
+    """
+    setup()
+    _piano._set_led_ramp_rate(_piano._cap_ctog, rise, fall)
+    _piano._set_led_ramp_rate(_piano._cap_atoc, rise, fall)

--- a/library/pianohat.py
+++ b/library/pianohat.py
@@ -1,22 +1,37 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""Piano HAT library for Raspberry Pi.
+
+This library provides an interface to the Piano HAT, a 13-key capacitive
+touch piano with additional control buttons.
+
+Requires the cap1xxx library for I2C communication with the capacitive
+touch controllers.
+"""
 
 import signal
 from sys import exit
+from typing import Callable, List, Optional, Union
 
 try:
     import cap1xxx
-except ImportError:
-    raise ImportError("This library requires the cap1xxx module\nInstall with: sudo pip install cap1xxx")
+except ImportError as exc:
+    raise ImportError(
+        "This library requires the cap1xxx module\n"
+        "Install with: pip3 install cap1xxx"
+    ) from exc
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
-_on_note        = None
-_on_octave_up   = None
-_on_octave_down = None
-_on_instrument  = None
+# Event handler type
+EventHandler = Optional[Callable[[int, bool], None]]
 
-_is_setup = False
-_pressed = [False for x in range(16)]
+_on_note: EventHandler = None
+_on_octave_up: EventHandler = None
+_on_octave_down: EventHandler = None
+_on_instrument: EventHandler = None
+
+_is_setup: bool = False
+_pressed: List[bool] = [False for x in range(16)]
 
 PRESSED  = True
 RELEASED = False
@@ -39,7 +54,9 @@ OCTAVE_DOWN = 13
 OCTAVE_UP   = 14
 INSTRUMENT  = 15
 
-def _setup_cap(cap):
+
+def _setup_cap(cap: 'cap1xxx.Cap1188') -> None:
+    """Configure a CAP1188 touch controller for Piano HAT use."""
     for x in range(8):
         cap._write_byte(0x30 + x, 0b00000110)
 
@@ -52,27 +69,31 @@ def _setup_cap(cap):
     cap._write_byte(cap1xxx.R_GENERAL_CONFIG, 0b00111000)
     cap._write_byte(cap1xxx.R_CONFIGURATION2, 0b01100000)
     cap.set_touch_delta(10)
-    cap.set_led_direct_ramp_rate(0,0)
+    cap.set_led_direct_ramp_rate(0, 0)
 
-def _handle_event(cap_index, event, state):
+
+def _handle_event(cap_index: int, event, state: bool) -> None:
+    """Handle touch events from the capacitive touch controllers."""
     global _pressed
     offset = 0
-    if cap_index == 1: offset = 8
+    if cap_index == 1:
+        offset = 8
  
     channel = offset + event.channel
 
     _pressed[channel] = (state == PRESSED)
     
-    if (channel) == OCTAVE_DOWN and callable(_on_octave_down):
+    if channel == OCTAVE_DOWN and callable(_on_octave_down):
         _on_octave_down(channel, state)
-    if (channel) == OCTAVE_UP   and callable(_on_octave_up):
+    if channel == OCTAVE_UP and callable(_on_octave_up):
         _on_octave_up(channel, state)
-    if (channel) == INSTRUMENT  and callable(_on_instrument):
+    if channel == INSTRUMENT and callable(_on_instrument):
         _on_instrument(channel, state)
-    if (channel) <= 12 and callable(_on_note):
+    if channel <= 12 and callable(_on_note):
         _on_note(channel, state)
 
-def auto_leds(enable = True):
+
+def auto_leds(enable: bool = True) -> None:
     """Enable or disable automatic LEDs
 
     :param enable: enable or disable: True/False
@@ -87,7 +108,8 @@ def auto_leds(enable = True):
     _piano_ctog._write_byte(cap1xxx.R_LED_LINKING, 0b11111111 * enable)
     _piano_atoc._write_byte(cap1xxx.R_LED_LINKING, 0b11111111 * enable)
 
-def set_led(index, state):
+
+def set_led(index: int, state: bool) -> None:
     """Turn an  LED on or off
 
     :param index: index of the LED to toggle: from 0 to 15
@@ -98,11 +120,12 @@ def set_led(index, state):
     setup()
 
     if index >= 8:
-        _piano_atoc.set_led_state(index-8,state)
+        _piano_atoc.set_led_state(index - 8, state)
     else:
-        _piano_ctog.set_led_state(index,state)
+        _piano_ctog.set_led_state(index, state)
 
-def set_led_ramp_rate(rise,fall):
+
+def set_led_ramp_rate(rise: int, fall: int) -> None:
     """Set the time it takes an LED to turn on or off
 
     :param rise: time it takes LED to light in milliseconds
@@ -115,7 +138,8 @@ def set_led_ramp_rate(rise,fall):
     _piano_ctog.set_led_direct_ramp_rate(rise, fall)
     _piano_atoc.set_led_direct_ramp_rate(rise, fall)
 
-def get_state(index=-1):
+
+def get_state(index: int = -1) -> Union[bool, List[bool]]:
     """Get the state of a single key
 
     :param index: index of key to return, from 0 to 15
@@ -129,7 +153,8 @@ def get_state(index=-1):
     else:
         return _pressed
 
-def on_note(handler):
+
+def on_note(handler: EventHandler) -> None:
     """Register handler for press/release of note key
 
     :param handler: handler function to register
@@ -145,7 +170,8 @@ def on_note(handler):
     setup()
     _on_note = handler
 
-def on_octave_up(handler):
+
+def on_octave_up(handler: EventHandler) -> None:
     """Register handler for press/release of octave_up key
 
     :param handler: handler function to register
@@ -158,7 +184,8 @@ def on_octave_up(handler):
     setup()
     _on_octave_up = handler
 
-def on_octave_down(handler):
+
+def on_octave_down(handler: EventHandler) -> None:
     """Register handler for press/release of octave_down key
 
     :param handler: handler function to register
@@ -171,7 +198,8 @@ def on_octave_down(handler):
     setup()
     _on_octave_down = handler
 
-def on_instrument(handler):
+
+def on_instrument(handler: EventHandler) -> None:
     """Register handler for press/release of instrument key
 
     :param handler: handler function to register
@@ -184,7 +212,8 @@ def on_instrument(handler):
     setup()
     _on_instrument = handler
 
-def setup():
+
+def setup() -> bool:
     global _is_setup, _piano_ctog, _piano_atoc
 
     if _is_setup:
@@ -198,14 +227,12 @@ def setup():
     _piano_atoc = cap1xxx.Cap1188(i2c_addr=0x2b, alert_pin=27)
     _setup_cap(_piano_atoc)
 
-    for x in range(0,8):
-        _piano_ctog.on(x,event='press',  handler=lambda evt: _handle_event(0,evt,PRESSED ))
-        _piano_ctog.on(x,event='release',handler=lambda evt: _handle_event(0,evt,RELEASED))
-        _piano_atoc.on(x,event='press',  handler=lambda evt: _handle_event(1,evt,PRESSED ))
-        _piano_atoc.on(x,event='release',handler=lambda evt: _handle_event(1,evt,RELEASED))
-
-    #_piano_ctog.clear_interrupt()
-    #_piano_atoc.clear_interrupt()
+    for x in range(0, 8):
+        _piano_ctog.on(x, event='press', handler=lambda evt: _handle_event(0, evt, PRESSED))
+        _piano_ctog.on(x, event='release', handler=lambda evt: _handle_event(0, evt, RELEASED))
+        _piano_atoc.on(x, event='press', handler=lambda evt: _handle_event(1, evt, PRESSED))
+        _piano_atoc.on(x, event='release', handler=lambda evt: _handle_event(1, evt, RELEASED))
 
     _is_setup = True
+    return True
 

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pianohat"
-version = "0.2.0"
+version = "0.3.1"
 description = "A 13-key Piano HAT library for Raspberry Pi"
 readme = "README.md"
 license = {text = "MIT"}
@@ -32,8 +32,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "cap1xxx>=0.1.3",
-    "smbus2>=0.4.0; platform_machine=='aarch64' or platform_machine=='armv7l' or platform_machine=='armv6l'",
+    "adafruit-circuitpython-cap1188>=1.3.17",
 ]
 
 [project.optional-dependencies]

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -1,0 +1,68 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pianohat"
+version = "0.2.0"
+description = "A 13-key Piano HAT library for Raspberry Pi"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [
+    {name = "Philip Howard", email = "phil@pimoroni.com"}
+]
+maintainers = [
+    {name = "Philip Howard", email = "phil@pimoroni.com"}
+]
+keywords = ["raspberry-pi", "piano", "hat", "capacitive-touch", "i2c"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Operating System :: POSIX :: Linux",
+    "License :: OSI Approved :: MIT License",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: System :: Hardware",
+]
+requires-python = ">=3.7"
+dependencies = [
+    "cap1xxx>=0.1.3",
+    "smbus2>=0.4.0; platform_machine=='aarch64' or platform_machine=='armv7l' or platform_machine=='armv6l'",
+]
+
+[project.optional-dependencies]
+examples = [
+    "pygame>=2.0.0",
+    "numpy>=1.19.0",
+]
+dev = [
+    "pytest>=7.0.0",
+    "black",
+    "flake8",
+    "mypy",
+]
+
+[project.urls]
+Homepage = "https://shop.pimoroni.com/products/piano-hat"
+Repository = "https://github.com/pimoroni/piano-hat"
+Documentation = "https://github.com/pimoroni/piano-hat"
+"Bug Tracker" = "https://github.com/pimoroni/piano-hat/issues"
+
+[tool.setuptools]
+py-modules = ["pianohat"]
+
+[tool.black]
+line-length = 120
+target-version = ["py37", "py38", "py39", "py310", "py311", "py312"]
+
+[tool.mypy]
+python_version = "3.7"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -1,0 +1,3 @@
+# Example dependencies for Piano HAT
+pygame>=2.0.0
+numpy>=1.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
 # Core dependencies for Piano HAT
-cap1xxx>=0.1.3
-smbus2>=0.4.0
+adafruit-circuitpython-cap1188>=1.3.17
 
-# System packages (install via apt on Raspberry Pi):
-# - i2c-tools
-# - python3-smbus (for system Python)
+# Note: The Adafruit library uses CircuitPython which works on Raspberry Pi via
+# the Blinka compatibility layer. I2C is required but no GPIO interrupts needed.
 
 # Optional dependencies for examples
 # Uncomment if you want to run the examples:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+# Core dependencies for Piano HAT
+cap1xxx>=0.1.3
+smbus2>=0.4.0
+
+# System packages (install via apt on Raspberry Pi):
+# - i2c-tools
+# - python3-smbus (for system Python)
+
+# Optional dependencies for examples
+# Uncomment if you want to run the examples:
+# pygame>=2.0.0
+# numpy>=1.19.0


### PR DESCRIPTION
A lot of this code was out of date for modern versions of Raspberry Pi OS and Python. What started as simple fixes turned into a total driver overhaul, and abandoning an incompatible driver to incorporate Adafruit's maintained driver.

AI Assistance Disclosure: This modernization was human-driven with GitHub Copilot assistance. All critical technical decisions, hardware troubleshooting, and architectural changes were human:

Human (me) contributions:

    Identified GPIO interrupt failures on Raspberry Pi OS Bookworm (gpiochip offset issues)
    Troubleshooting and investigation of incompatibility leading to decision to migrate from deprecated cap1xxx to actively-maintained adafruit-circuitpython-cap1188
    Discovered through hardware investigation that the CAP1188 chips have onboard LED control registers (not separate GPIO controllers as initially assumed) and re-incorporated that into this driver. (it is not part of Adafruit's library)
    Designed polling-based architecture to eliminate GPIO interrupt dependency
    Debugged I2C addressing for dual-chip configuration (0x28, 0x2b) since 0x29 is the default from Adafruit.
    Implemented register-level LED control (R_LED_LINKING, R_LED_OUTPUT_CON, R_LED_BEHAVIOUR, R_LED_DIRECT_RAMP)
    Tested and verified hardware functionality on target platform (a Raspberry Pi Zero 2W, in this case)

GitHub Copilot contributions:

    Code scaffolding and boilerplate generation
    Syntax error checking and code formatting
    Comment and docstring improvements
    Open-source attribution compliance (SPDX headers)
    Documentation consistency verification

The concepts, problem-solving, and hardware-level implementation were human-driven. Copilot accelerated the execution.
